### PR TITLE
feat: add --compare flag for before/after comparison output

### DIFF
--- a/src/spritegrid/cli.py
+++ b/src/spritegrid/cli.py
@@ -103,6 +103,12 @@ def parse_args() -> argparse.Namespace:
         type=int,
     )
 
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="Output a side-by-side before/after comparison image instead of just the result.",
+    )
+
     args = parser.parse_args()
 
     # Ensure the crop argument is passed correctly
@@ -129,6 +135,7 @@ def cli() -> None:
         remove_background=args.remove_background,
         crop=args.crop,
         ascii_space_width=args.ascii,
+        compare=args.compare,
     )
 
 

--- a/src/spritegrid/main.py
+++ b/src/spritegrid/main.py
@@ -216,6 +216,69 @@ def create_downsampled_image(
     return new_img
 
 
+def create_comparison_image(
+    before: Image.Image,
+    after: Image.Image,
+    label_height: int = 16,
+    divider_width: int = 2,
+) -> Image.Image:
+    """Create a side-by-side before/after comparison image.
+
+    The *after* image is scaled up to match the *before* image's dimensions
+    using NEAREST resampling to preserve hard pixel edges. Both panels are
+    labelled "Before" and "After" in white text on a dark bar.
+
+    Args:
+        before: The original (unprocessed) image.
+        after: The processed (downsampled) image.
+        label_height: Height in pixels of the label bar above each panel.
+        divider_width: Width of the vertical divider between panels.
+
+    Returns:
+        A new PIL Image containing the side-by-side comparison.
+    """
+    target_w, target_h = before.width, before.height
+
+    # Scale the after image up to the same canvas size using NEAREST (pixel-art safe)
+    after_scaled = after.resize((target_w, target_h), resample=Image.NEAREST)
+
+    # Ensure both are in RGBA so we can composite safely
+    before_rgb = before.convert("RGBA")
+    after_rgb = after_scaled.convert("RGBA")
+
+    total_w = target_w * 2 + divider_width
+    total_h = target_h + label_height
+
+    canvas = Image.new("RGBA", (total_w, total_h), (30, 30, 30, 255))
+
+    # Paste panels
+    canvas.paste(before_rgb, (0, label_height))
+    # Divider stays dark (already the background color)
+    canvas.paste(after_rgb, (target_w + divider_width, label_height))
+
+    # Draw labels (only if there is space for them)
+    if label_height > 0:
+        draw = ImageDraw.Draw(canvas)
+        label_bg = (40, 40, 40, 255)
+        text_color = (230, 230, 230, 255)
+
+        draw.rectangle([0, 0, target_w - 1, label_height - 1], fill=label_bg)
+        draw.rectangle([target_w + divider_width, 0, total_w - 1, label_height - 1], fill=label_bg)
+
+        # Centre each label text horizontally within its panel
+        before_bbox = draw.textbbox((0, 0), "Before")
+        after_bbox = draw.textbbox((0, 0), "After")
+
+        before_x = (target_w - (before_bbox[2] - before_bbox[0])) // 2
+        after_x = target_w + divider_width + (target_w - (after_bbox[2] - after_bbox[0])) // 2
+        label_y = (label_height - (before_bbox[3] - before_bbox[1])) // 2
+
+        draw.text((before_x, label_y), "Before", fill=text_color)
+        draw.text((after_x, label_y), "After", fill=text_color)
+
+    return canvas
+
+
 def handle_output(
     image: Image.Image,
     save_path: Optional[str],
@@ -299,6 +362,7 @@ def main(
     remove_background: Optional[str] = None,
     crop: bool = False,
     ascii_space_width: Optional[int] = None,
+    compare: bool = False,
 ) -> None:
     """
     Main function to parse arguments, load image, detect grid, and generate output/debug image.
@@ -392,7 +456,18 @@ def main(
                 output_image = crop_to_content(output_image)
                 print(f"Image cropped to {output_image.width}x{output_image.height}")
 
-        if debug:
+        if compare and not debug and not is_already_clean:
+            print("\n--- Generating Before/After Comparison ---")
+            comparison = create_comparison_image(image, output_image)
+            handle_output(
+                comparison,
+                output_file,
+                show,
+                is_debug=False,
+                default_title=f"{image_source} — Before / After",
+                ascii_space_width=ascii_space_width,
+            )
+        elif debug:
             handle_output(
                 debug_image,
                 output_file,

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,74 @@
+"""Tests for the before/after comparison feature."""
+
+import pytest
+from PIL import Image
+
+from spritegrid.main import create_comparison_image
+
+
+def _solid(width: int, height: int, color=(255, 0, 0)) -> Image.Image:
+    return Image.new("RGB", (width, height), color=color)
+
+
+class TestCreateComparisonImage:
+    def test_output_width_is_double_plus_divider(self):
+        before = _solid(64, 32)
+        after = _solid(8, 4)
+        comp = create_comparison_image(before, after, divider_width=2)
+        assert comp.width == 64 * 2 + 2
+
+    def test_output_height_includes_label_bar(self):
+        before = _solid(64, 32)
+        after = _solid(8, 4)
+        comp = create_comparison_image(before, after, label_height=16)
+        assert comp.height == 32 + 16
+
+    def test_after_panel_is_scaled_to_before_size(self):
+        """The after image should be upscaled to the before's dimensions."""
+        before = _solid(64, 32, color=(255, 0, 0))
+        after = _solid(8, 4, color=(0, 0, 255))
+        comp = create_comparison_image(before, after, label_height=0, divider_width=0)
+        # Right half should be blue (upscaled after image)
+        right_pixel = comp.convert("RGBA").getpixel((64, 0))
+        assert right_pixel[2] == 255, "Right panel should be blue (after image)"
+
+    def test_before_panel_appears_on_left(self):
+        before = _solid(64, 32, color=(255, 0, 0))
+        after = _solid(8, 4, color=(0, 0, 255))
+        comp = create_comparison_image(before, after, label_height=0, divider_width=0)
+        # Left half should be red (before image)
+        left_pixel = comp.convert("RGBA").getpixel((0, 0))
+        assert left_pixel[0] == 255, "Left panel should be red (before image)"
+        assert left_pixel[2] == 0, "Left panel should not be blue"
+
+    def test_square_before_image(self):
+        before = _solid(32, 32)
+        after = _solid(16, 16)
+        comp = create_comparison_image(before, after, label_height=16, divider_width=2)
+        assert comp.size == (32 * 2 + 2, 32 + 16)
+
+    def test_returns_rgba_image(self):
+        before = _solid(32, 16)
+        after = _solid(4, 2)
+        comp = create_comparison_image(before, after)
+        assert comp.mode == "RGBA"
+
+    def test_custom_divider_width(self):
+        before = _solid(64, 32)
+        after = _solid(8, 4)
+        for dw in [0, 1, 4, 10]:
+            comp = create_comparison_image(before, after, divider_width=dw)
+            assert comp.width == 64 * 2 + dw
+
+    def test_custom_label_height(self):
+        before = _solid(64, 32)
+        after = _solid(8, 4)
+        for lh in [0, 8, 24]:
+            comp = create_comparison_image(before, after, label_height=lh)
+            assert comp.height == 32 + lh
+
+    def test_rgba_input_preserved(self):
+        before = Image.new("RGBA", (32, 16), (255, 0, 0, 128))
+        after = Image.new("RGBA", (4, 2), (0, 255, 0, 200))
+        comp = create_comparison_image(before, after, label_height=0)
+        assert comp.mode == "RGBA"


### PR DESCRIPTION
## Summary

- Adds `--compare` CLI flag to `spritegrid`
- When set, outputs a side-by-side comparison image with "Before" and "After" labels instead of just the processed result
- The processed image is upscaled to the original's dimensions using NEAREST resampling (pixel-art safe) before compositing
- Suppressed in `--debug` mode and when the image is already clean pixel art (1:1 detection)
- 9 new unit tests in `tests/test_compare.py`

## Usage

```bash
spritegrid input.png --compare -o comparison.png
spritegrid input.png --compare -i  # show in viewer
```

## Test plan
- [x] 44 tests pass (`uv run pytest`)
- [x] `test_compare.py` covers size, pixel content, RGBA handling, and parameter variants

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)