### PR TITLE
feat: add --res and --aspectratio flags for custom output dimensions

### DIFF
--- a/src/spritegrid/cli.py
+++ b/src/spritegrid/cli.py
@@ -5,6 +5,30 @@ from typing import Optional, Tuple
 from .main import main
 
 
+def parse_aspect_ratio(ratio_str: str) -> Tuple[int, int]:
+    """Parse an aspect ratio string like '4:3' into (width, height) tuple."""
+    if ":" not in ratio_str:
+        raise argparse.ArgumentTypeError(
+            f"Invalid aspect ratio format: {ratio_str!r}. Use 'W:H' (e.g., '4:3' or '16:9')."
+        )
+    parts = ratio_str.split(":")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError(
+            f"Invalid aspect ratio format: {ratio_str!r}. Use 'W:H' (e.g., '4:3')."
+        )
+    try:
+        w, h = int(parts[0]), int(parts[1])
+        if w <= 0 or h <= 0:
+            raise argparse.ArgumentTypeError(
+                f"Aspect ratio values must be positive integers: {ratio_str!r}"
+            )
+        return (w, h)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"Invalid aspect ratio format: {ratio_str!r}. Values must be integers."
+        )
+
+
 def parse_size(size_str: str) -> Tuple[int, int]:
     """Parse a size string like '32' or '32x48' into (width, height) tuple."""
     if "x" in size_str.lower():
@@ -103,6 +127,28 @@ def parse_args() -> argparse.Namespace:
         type=int,
     )
 
+    parser.add_argument(
+        "--res",
+        type=parse_size,
+        metavar="WxH",
+        default=None,
+        help=(
+            "Force the output image to this exact resolution (e.g. '32x32' or '16x24') "
+            "using NEAREST resampling. Overrides --aspectratio."
+        ),
+    )
+
+    parser.add_argument(
+        "--aspectratio",
+        type=parse_aspect_ratio,
+        metavar="W:H",
+        default=None,
+        help=(
+            "Center-crop the output to the given aspect ratio (e.g. '4:3' or '16:9'). "
+            "Ignored when --res is specified."
+        ),
+    )
+
     args = parser.parse_args()
 
     # Ensure the crop argument is passed correctly
@@ -129,6 +175,8 @@ def cli() -> None:
         remove_background=args.remove_background,
         crop=args.crop,
         ascii_space_width=args.ascii,
+        res=args.res,
+        aspect_ratio=args.aspectratio,
     )
 
 

--- a/src/spritegrid/main.py
+++ b/src/spritegrid/main.py
@@ -1,6 +1,6 @@
 import io
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 import requests
 from PIL import Image, ImageDraw
@@ -289,6 +289,48 @@ def handle_png(image: Image.Image, save_path: str) -> None:
             file=sys.stderr,
         )
 
+def apply_resolution(
+    image: Image.Image,
+    target: Tuple[int, int],
+) -> Image.Image:
+    """Resize *image* to *target* (width, height) using NEAREST resampling.
+
+    NEAREST is used to preserve the hard pixel edges of pixel art.
+    """
+    if image.size == target:
+        return image
+    print(f"Resizing output from {image.width}x{image.height} to {target[0]}x{target[1]}...")
+    return image.resize(target, resample=Image.NEAREST)
+
+
+def apply_aspect_ratio(
+    image: Image.Image,
+    aspect: Tuple[int, int],
+) -> Image.Image:
+    """Center-crop *image* to the given aspect ratio (w_ratio, h_ratio).
+
+    The crop is the largest rectangle with the given aspect that fits inside
+    the image. The image is not padded — content may be lost at the edges.
+    """
+    ratio_w, ratio_h = aspect
+    src_w, src_h = image.size
+
+    # Target dimensions: constrain by whichever axis is the bottleneck
+    target_w = src_w
+    target_h = round(src_w * ratio_h / ratio_w)
+    if target_h > src_h:
+        target_h = src_h
+        target_w = round(src_h * ratio_w / ratio_h)
+
+    if (target_w, target_h) == (src_w, src_h):
+        return image
+
+    left = (src_w - target_w) // 2
+    top = (src_h - target_h) // 2
+    print(f"Cropping output from {src_w}x{src_h} to {target_w}x{target_h} ({ratio_w}:{ratio_h})...")
+    return image.crop((left, top, left + target_w, top + target_h))
+
+
 def main(
     image_source: str,
     min_grid: int = 4,
@@ -299,6 +341,8 @@ def main(
     remove_background: Optional[str] = None,
     crop: bool = False,
     ascii_space_width: Optional[int] = None,
+    res: Optional[Tuple[int, int]] = None,
+    aspect_ratio: Optional[Tuple[int, int]] = None,
 ) -> None:
     """
     Main function to parse arguments, load image, detect grid, and generate output/debug image.
@@ -391,6 +435,12 @@ def main(
                 print("Automatically cropping the image to non-transparent content...")
                 output_image = crop_to_content(output_image)
                 print(f"Image cropped to {output_image.width}x{output_image.height}")
+
+            # Apply custom resolution (--res) — takes precedence over --aspectratio
+            if res is not None:
+                output_image = apply_resolution(output_image, res)
+            elif aspect_ratio is not None:
+                output_image = apply_aspect_ratio(output_image, aspect_ratio)
 
         if debug:
             handle_output(

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -1,0 +1,121 @@
+"""Tests for --res and --aspectratio features."""
+
+import pytest
+from PIL import Image
+
+from spritegrid.main import apply_resolution, apply_aspect_ratio
+from spritegrid.cli import parse_aspect_ratio, parse_size
+import argparse
+
+
+# ---------------------------------------------------------------------------
+# parse_aspect_ratio
+# ---------------------------------------------------------------------------
+
+class TestParseAspectRatio:
+    def test_standard_ratio(self):
+        assert parse_aspect_ratio("4:3") == (4, 3)
+
+    def test_widescreen(self):
+        assert parse_aspect_ratio("16:9") == (16, 9)
+
+    def test_square(self):
+        assert parse_aspect_ratio("1:1") == (1, 1)
+
+    def test_missing_colon_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_aspect_ratio("43")
+
+    def test_non_integer_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_aspect_ratio("4.5:3")
+
+    def test_zero_value_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_aspect_ratio("0:3")
+
+    def test_negative_value_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_aspect_ratio("-1:3")
+
+
+# ---------------------------------------------------------------------------
+# apply_resolution
+# ---------------------------------------------------------------------------
+
+class TestApplyResolution:
+    def test_upscale(self):
+        img = Image.new("RGB", (8, 4))
+        result = apply_resolution(img, (16, 8))
+        assert result.size == (16, 8)
+
+    def test_downscale(self):
+        img = Image.new("RGB", (64, 32))
+        result = apply_resolution(img, (16, 8))
+        assert result.size == (16, 8)
+
+    def test_identity_returns_original(self):
+        img = Image.new("RGB", (32, 32))
+        result = apply_resolution(img, (32, 32))
+        assert result is img  # same object — no copy made
+
+    def test_non_square_target(self):
+        img = Image.new("RGB", (32, 32))
+        result = apply_resolution(img, (64, 32))
+        assert result.size == (64, 32)
+
+    def test_preserves_pixel_values(self):
+        """NEAREST resampling should preserve the exact color of the upscaled pixels."""
+        img = Image.new("RGB", (1, 1), color=(255, 0, 0))
+        result = apply_resolution(img, (4, 4))
+        assert result.getpixel((0, 0)) == (255, 0, 0)
+        assert result.getpixel((3, 3)) == (255, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# apply_aspect_ratio
+# ---------------------------------------------------------------------------
+
+class TestApplyAspectRatio:
+    def test_4_3_on_square(self):
+        """4:3 crop on 32x32 should give 32x24."""
+        img = Image.new("RGB", (32, 32))
+        result = apply_aspect_ratio(img, (4, 3))
+        assert result.size == (32, 24)
+        assert result.width * 3 == result.height * 4
+
+    def test_16_9_on_square(self):
+        """16:9 crop on 32x32 → 32x18."""
+        img = Image.new("RGB", (32, 32))
+        result = apply_aspect_ratio(img, (16, 9))
+        assert result.height == 18
+
+    def test_portrait_crop(self):
+        """3:4 on 32x32 should give 24x32."""
+        img = Image.new("RGB", (32, 32))
+        result = apply_aspect_ratio(img, (3, 4))
+        assert result.size == (24, 32)
+
+    def test_already_correct_ratio(self):
+        """No crop needed when image already has the right ratio."""
+        img = Image.new("RGB", (16, 12))
+        result = apply_aspect_ratio(img, (4, 3))
+        assert result.size == (16, 12)
+
+    def test_returns_original_when_no_crop_needed(self):
+        img = Image.new("RGB", (16, 12))
+        result = apply_aspect_ratio(img, (4, 3))
+        assert result is img
+
+    def test_crop_is_centered(self):
+        """Center crop: pixels at the sides should be removed, not from one end."""
+        # 4:1 wide image, crop to 1:1 — should remove equal amounts from left and right
+        img = Image.new("RGB", (40, 10), color=(0, 0, 0))
+        # Mark left and right edges red
+        for y in range(10):
+            img.putpixel((0, y), (255, 0, 0))
+            img.putpixel((39, y), (255, 0, 0))
+        result = apply_aspect_ratio(img, (1, 1))
+        # Corners should not be red (they were removed in the crop)
+        assert result.getpixel((0, 0)) != (255, 0, 0)
+        assert result.getpixel((result.width - 1, 0)) != (255, 0, 0)


### PR DESCRIPTION
## Summary

- `--res WxH` — force the output to an exact resolution (e.g. `32x32`, `16x24`) using NEAREST resampling
- `--aspectratio W:H` — center-crop the output to a given aspect ratio (e.g. `4:3`, `16:9`)
- `--res` takes precedence when both flags are given
- 18 unit tests covering parsing, resizing, cropping, centering, and edge cases

## Usage

```bash
spritegrid input.png --res 32x32 -o sprite.png
spritegrid input.png --aspectratio 4:3 -o cropped.png
spritegrid input.png --res 64x48 --aspectratio 4:3 -o sprite.png  # --res wins
```

## Test plan
- [x] 53 tests pass (`uv run pytest`)
- [x] `test_resolution.py` covers `parse_aspect_ratio`, `apply_resolution`, `apply_aspect_ratio`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)