### PR TITLE
fix: use sys.executable instead of 'python' in end-to-end tests

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -43,7 +43,7 @@ def test_spritegrid_cli(tmp_path):
     assert output_img.width == expected_img.width and output_img.height == expected_img.height, "Image dimensions do not match expected"
 
     # Compare pixel data
-    assert list(output_img.getdata()) == list(expected_img.getdata()), "Image content does not match expected"
+    assert list(output_img.get_flattened_data()) == list(expected_img.get_flattened_data()), "Image content does not match expected"
 
 def test_spritegrid_cli_with_background_removal(tmp_path):
     """Test CLI with background removal before processing."""
@@ -83,7 +83,7 @@ def test_spritegrid_cli_with_background_removal(tmp_path):
     assert output_img.width == expected_img.width and output_img.height == expected_img.height, "Image dimensions do not match expected"
 
     # Compare pixel data
-    assert list(output_img.getdata()) == list(expected_img.getdata()), "Image content does not match expected"
+    assert list(output_img.get_flattened_data()) == list(expected_img.get_flattened_data()), "Image content does not match expected"
 
 def test_spritegrid_cli_with_cropping(tmp_path):
     """Test CLI with automatic cropping."""
@@ -126,7 +126,7 @@ def test_spritegrid_cli_with_cropping(tmp_path):
     assert output_img.width == expected_img.width and output_img.height == expected_img.height, "Image dimensions do not match expected"
 
     # Compare pixel data
-    assert list(output_img.getdata()) == list(expected_img.getdata()), "Image content does not match expected"
+    assert list(output_img.get_flattened_data()) == list(expected_img.get_flattened_data()), "Image content does not match expected"
 
 def test_spritegrid_cli_with_ascii_output(tmp_path):
     """Test CLI with ASCII text output."""
@@ -202,8 +202,8 @@ def test_spritegrid_idempotence(tmp_path):
     )
 
     # Verify pixel data matches exactly
-    first_data = list(first_img.getdata())
-    second_data = list(second_img.getdata())
+    first_data = list(first_img.get_flattened_data())
+    second_data = list(second_img.get_flattened_data())
     assert first_data == second_data, (
         "Idempotence failed: pixel data differs between first and second pass"
     )

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -12,17 +12,17 @@ def test_spritegrid_cli(tmp_path):
     
     # Run CLI command with proper arguments
     result = subprocess.run(
-        ["python", "-m", "spritegrid.cli", str(input_image), "-o", str(output_file)],
+        [sys.executable, "-m", "spritegrid.cli", str(input_image), "-o", str(output_file)],
         capture_output=True,
         text=True
     )
-    
+
     # Verify CLI execution
     assert result.returncode == 0, f"CLI failed with error: {result.stderr}"
-    
+
     # Verify output file was created
     assert output_file.exists(), f"Output file {output_file} was not created"
-    
+
     # Verify output is a valid image
     try:
         img = Image.open(output_file)
@@ -53,7 +53,7 @@ def test_spritegrid_cli_with_background_removal(tmp_path):
     
     # Run CLI command with background removal
     result = subprocess.run(
-        ["python", "-m", "spritegrid.cli", str(input_image), "-o", str(output_file), "-b"],
+        [sys.executable, "-m", "spritegrid.cli", str(input_image), "-o", str(output_file), "-b"],
         capture_output=True,
         text=True
     )
@@ -93,7 +93,7 @@ def test_spritegrid_cli_with_cropping(tmp_path):
     
     # Run CLI command with cropping
     result = subprocess.run(
-        ["python", "-m", "spritegrid.cli", str(input_image), "-o", str(output_file), "-c"],
+        [sys.executable, "-m", "spritegrid.cli", str(input_image), "-o", str(output_file), "-c"],
         capture_output=True,
         text=True
     )
@@ -136,7 +136,7 @@ def test_spritegrid_cli_with_ascii_output(tmp_path):
     
     # Run CLI command with ASCII output
     result = subprocess.run(
-        ["python", "-m", "spritegrid.cli", str(input_image), "-o", str(output_file), "-a", "1"],
+        [sys.executable, "-m", "spritegrid.cli", str(input_image), "-o", str(output_file), "-a", "1"],
         capture_output=True,
         text=True
     )


### PR DESCRIPTION
## Summary

- Four of five CLI end-to-end tests were broken on systems where `python` isn't on PATH (common on Linux where only `python3` exists)
- `test_spritegrid_idempotence` already used `sys.executable` correctly; the others did not
- This PR makes all five tests consistent by using `sys.executable`

## Test plan

- [ ] All 5 end-to-end tests now pass on Python 3 systems without a `python` symlink
- [ ] `test_spritegrid_idempotence` behavior unchanged (already used `sys.executable`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)