### PR TITLE
test: 29 tests for comfyui/nodes.py (tensor_to_pil, pil_to_tensor, SpriteGrid metadata)

### DIFF
--- a/tests/test_comfyui_nodes.py
+++ b/tests/test_comfyui_nodes.py
@@ -1,0 +1,215 @@
+"""Tests for spritegrid/comfyui/nodes.py — tensor/PIL converters and SpriteGrid node metadata."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from spritegrid.comfyui.nodes import (
+    NODE_CLASS_MAPPINGS,
+    NODE_DISPLAY_NAME_MAPPINGS,
+    SpriteGrid,
+    pil_to_tensor,
+    tensor_to_pil,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _rgb_tensor(h: int, w: int, r: float = 0.5, g: float = 0.3, b: float = 0.2) -> torch.Tensor:
+    """Create a (1, h, w, 3) float32 tensor with uniform colour."""
+    t = torch.zeros(1, h, w, 3)
+    t[0, :, :, 0] = r
+    t[0, :, :, 1] = g
+    t[0, :, :, 2] = b
+    return t
+
+
+def _rgba_tensor(h: int, w: int, a: float = 1.0) -> torch.Tensor:
+    """Create a (1, h, w, 4) float32 tensor with full alpha."""
+    t = torch.zeros(1, h, w, 4)
+    t[0, :, :, 3] = a
+    return t
+
+
+# ---------------------------------------------------------------------------
+# tensor_to_pil
+# ---------------------------------------------------------------------------
+
+class TestTensorToPil:
+    def test_rgb_input_returns_rgb_image(self):
+        t = _rgb_tensor(8, 8)
+        img = tensor_to_pil(t)
+        assert img.mode == "RGB"
+
+    def test_rgba_input_returns_rgba_image(self):
+        t = _rgba_tensor(8, 8)
+        img = tensor_to_pil(t)
+        assert img.mode == "RGBA"
+
+    def test_output_size_matches_tensor(self):
+        t = _rgb_tensor(16, 32)
+        img = tensor_to_pil(t)
+        assert img.size == (32, 16)  # PIL size is (width, height)
+
+    def test_pixel_values_scaled_to_0_255(self):
+        # Tensor value 1.0 → pixel 255, 0.0 → pixel 0
+        t = torch.ones(1, 4, 4, 3)  # all 1.0
+        img = tensor_to_pil(t)
+        arr = np.array(img)
+        assert arr.max() == 255
+
+    def test_zero_tensor_gives_black_image(self):
+        t = torch.zeros(1, 4, 4, 3)
+        img = tensor_to_pil(t)
+        arr = np.array(img)
+        assert arr.max() == 0
+
+    def test_returns_pil_image_instance(self):
+        t = _rgb_tensor(4, 4)
+        img = tensor_to_pil(t)
+        assert isinstance(img, Image.Image)
+
+    def test_batch_dim_squeezed(self):
+        # Shape (1, h, w, c) should not crash — batch dim is squeezed
+        t = _rgb_tensor(4, 4)
+        assert t.shape[0] == 1
+        img = tensor_to_pil(t)
+        assert img.size == (4, 4)
+
+    def test_rgba_alpha_channel_preserved(self):
+        t = _rgba_tensor(4, 4, a=0.5)  # alpha=0.5 → pixel ~127
+        img = tensor_to_pil(t)
+        arr = np.array(img)
+        alpha = arr[:, :, 3]
+        # 0.5 * 255 clipped to int is either 127 or 128
+        assert 126 <= alpha.mean() <= 129
+
+
+# ---------------------------------------------------------------------------
+# pil_to_tensor
+# ---------------------------------------------------------------------------
+
+class TestPilToTensor:
+    def test_returns_float32_tensor(self):
+        img = Image.new("RGB", (8, 8), (128, 64, 32))
+        t = pil_to_tensor(img)
+        assert t.dtype == torch.float32
+
+    def test_output_shape_is_1_h_w_4(self):
+        img = Image.new("RGB", (6, 10), (0, 0, 0))
+        t = pil_to_tensor(img)
+        assert t.shape == (1, 10, 6, 4)
+
+    def test_rgb_image_converted_to_rgba(self):
+        img = Image.new("RGB", (4, 4), (255, 0, 0))
+        t = pil_to_tensor(img)
+        # RGBA → 4 channels
+        assert t.shape[-1] == 4
+
+    def test_values_in_zero_one_range(self):
+        img = Image.new("RGB", (4, 4), (200, 100, 50))
+        t = pil_to_tensor(img)
+        assert t.min().item() >= 0.0
+        assert t.max().item() <= 1.0
+
+    def test_white_image_values_near_one(self):
+        img = Image.new("RGB", (4, 4), (255, 255, 255))
+        t = pil_to_tensor(img)
+        # RGB channels of white are all 1.0
+        assert torch.allclose(t[0, :, :, :3], torch.ones(4, 4, 3), atol=0.01)
+
+    def test_black_image_rgb_values_zero(self):
+        img = Image.new("RGB", (4, 4), (0, 0, 0))
+        t = pil_to_tensor(img)
+        assert torch.allclose(t[0, :, :, :3], torch.zeros(4, 4, 3), atol=0.01)
+
+    def test_rgba_image_preserved(self):
+        img = Image.new("RGBA", (4, 4), (255, 0, 0, 128))
+        t = pil_to_tensor(img)
+        assert t.shape[-1] == 4
+        # Alpha channel ~128/255 ≈ 0.502
+        assert abs(t[0, 0, 0, 3].item() - 128 / 255) < 0.01
+
+    def test_size_h_w_order(self):
+        img = Image.new("RGB", (12, 8))  # width=12, height=8
+        t = pil_to_tensor(img)
+        assert t.shape == (1, 8, 12, 4)
+
+
+# ---------------------------------------------------------------------------
+# SpriteGrid node — metadata
+# ---------------------------------------------------------------------------
+
+class TestSpriteGridMetadata:
+    def test_return_types_is_tuple_with_image(self):
+        assert SpriteGrid.RETURN_TYPES == ("IMAGE",)
+
+    def test_function_is_process(self):
+        assert SpriteGrid.FUNCTION == "process"
+
+    def test_category_contains_image(self):
+        assert "image" in SpriteGrid.CATEGORY.lower()
+
+    def test_input_types_has_required_image(self):
+        types = SpriteGrid.INPUT_TYPES()
+        assert "required" in types
+        assert "image" in types["required"]
+
+    def test_input_types_has_optional_fields(self):
+        types = SpriteGrid.INPUT_TYPES()
+        assert "optional" in types
+        optional = types["optional"]
+        assert "min_grid" in optional
+        assert "quantize" in optional
+        assert "remove_background" in optional
+        assert "crop" in optional
+
+    def test_min_grid_default_is_4(self):
+        types = SpriteGrid.INPUT_TYPES()
+        min_grid = types["optional"]["min_grid"]
+        assert min_grid[1]["default"] == 4
+
+    def test_quantize_default_is_8(self):
+        types = SpriteGrid.INPUT_TYPES()
+        quantize = types["optional"]["quantize"]
+        assert quantize[1]["default"] == 8
+
+    def test_remove_background_choices(self):
+        types = SpriteGrid.INPUT_TYPES()
+        choices = types["optional"]["remove_background"][0]
+        assert "none" in choices
+        assert "before" in choices
+        assert "after" in choices
+
+    def test_crop_default_is_false(self):
+        types = SpriteGrid.INPUT_TYPES()
+        crop = types["optional"]["crop"]
+        assert crop[1]["default"] is False
+
+
+# ---------------------------------------------------------------------------
+# Module-level mappings
+# ---------------------------------------------------------------------------
+
+class TestNodeMappings:
+    def test_spritegrid_in_class_mappings(self):
+        assert "SpriteGrid" in NODE_CLASS_MAPPINGS
+
+    def test_class_mappings_points_to_class(self):
+        assert NODE_CLASS_MAPPINGS["SpriteGrid"] is SpriteGrid
+
+    def test_spritegrid_in_display_name_mappings(self):
+        assert "SpriteGrid" in NODE_DISPLAY_NAME_MAPPINGS
+
+    def test_display_name_is_string(self):
+        assert isinstance(NODE_DISPLAY_NAME_MAPPINGS["SpriteGrid"], str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,183 @@
+"""Tests for spritegrid.utils — convert_image_to_ascii, naive_median,
+geometric_median, crop_to_content."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from spritegrid.utils import (
+    convert_image_to_ascii,
+    crop_to_content,
+    geometric_median,
+    naive_median,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _rgba(w: int, h: int, color=(255, 0, 0, 255)) -> Image.Image:
+    arr = np.full((h, w, 4), color, dtype=np.uint8)
+    return Image.fromarray(arr)
+
+
+def _transparent(w: int, h: int) -> Image.Image:
+    arr = np.zeros((h, w, 4), dtype=np.uint8)
+    return Image.fromarray(arr)
+
+
+# ---------------------------------------------------------------------------
+# naive_median
+# ---------------------------------------------------------------------------
+
+class TestNaiveMedian:
+    def test_single_point(self):
+        X = np.array([[3.0, 7.0]])
+        result = naive_median(X)
+        np.testing.assert_allclose(result, [3.0, 7.0])
+
+    def test_two_points(self):
+        X = np.array([[0.0, 0.0], [2.0, 4.0]])
+        result = naive_median(X)
+        np.testing.assert_allclose(result, [1.0, 2.0])
+
+    def test_symmetric_returns_center(self):
+        X = np.array([[-1.0], [0.0], [1.0]])
+        result = naive_median(X)
+        np.testing.assert_allclose(result, [0.0])
+
+    def test_1d_array(self):
+        X = np.array([[1.0], [3.0], [5.0], [7.0]])
+        result = naive_median(X)
+        np.testing.assert_allclose(result, [4.0])
+
+    def test_returns_ndarray(self):
+        X = np.array([[1.0, 2.0], [3.0, 4.0]])
+        assert isinstance(naive_median(X), np.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# geometric_median
+# ---------------------------------------------------------------------------
+
+class TestGeometricMedian:
+    def test_single_point_returns_itself(self):
+        X = np.array([[5.0, 3.0]])
+        result = geometric_median(X)
+        np.testing.assert_allclose(result, [5.0, 3.0], atol=1e-4)
+
+    def test_symmetric_points_converge_to_center(self):
+        X = np.array([
+            [-1.0, 0.0], [1.0, 0.0],
+            [0.0, -1.0], [0.0, 1.0],
+        ])
+        result = geometric_median(X)
+        np.testing.assert_allclose(result, [0.0, 0.0], atol=0.01)
+
+    def test_result_close_to_true_median(self):
+        rng = np.random.default_rng(42)
+        X = rng.uniform(-10, 10, (50, 2))
+        gm = geometric_median(X)
+        nm = naive_median(X)
+        # Geometric median should be reasonably close to naive median
+        assert np.linalg.norm(gm - nm) < 5.0
+
+    def test_collinear_points(self):
+        X = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0], [10.0, 0.0]])
+        result = geometric_median(X)
+        # Geometric median is robust to outliers; should be between 1 and 3
+        assert 1.0 <= result[0] <= 3.0
+
+    def test_returns_ndarray(self):
+        X = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        result = geometric_median(X)
+        assert isinstance(result, np.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# convert_image_to_ascii
+# ---------------------------------------------------------------------------
+
+class TestConvertImageToAscii:
+    def test_single_opaque_pixel_contains_ansi(self):
+        img = _rgba(1, 1, (255, 0, 0, 255))
+        result = convert_image_to_ascii(img)
+        assert "\x1b[48;2;" in result
+
+    def test_single_transparent_pixel_is_space(self):
+        img = _transparent(1, 1)
+        result = convert_image_to_ascii(img)
+        # Should be a space (no ANSI codes) + newline
+        assert "\x1b" not in result
+        assert " " in result
+
+    def test_output_has_newlines_per_row(self):
+        img = _rgba(3, 2)
+        result = convert_image_to_ascii(img)
+        assert result.count("\n") == 2
+
+    def test_ascii_space_width_one(self):
+        img = _rgba(2, 1)
+        result_1 = convert_image_to_ascii(img, ascii_space_width=1)
+        result_2 = convert_image_to_ascii(img, ascii_space_width=2)
+        # Wider spacing means longer string
+        assert len(result_2) > len(result_1)
+
+    def test_rgb_color_encoded_in_output(self):
+        img = _rgba(1, 1, (10, 20, 30, 255))
+        result = convert_image_to_ascii(img)
+        assert "10;20;30" in result
+
+    def test_zero_space_width_raises(self):
+        img = _rgba(1, 1)
+        with pytest.raises(AssertionError):
+            convert_image_to_ascii(img, ascii_space_width=0)
+
+    def test_returns_string(self):
+        img = _rgba(2, 2)
+        assert isinstance(convert_image_to_ascii(img), str)
+
+
+# ---------------------------------------------------------------------------
+# crop_to_content
+# ---------------------------------------------------------------------------
+
+class TestCropToContent:
+    def test_already_tight_image_unchanged_size(self):
+        img = _rgba(4, 4, (255, 0, 0, 255))
+        cropped = crop_to_content(img)
+        assert cropped.size == (4, 4)
+
+    def test_fully_transparent_returns_original(self):
+        img = _transparent(8, 8)
+        result = crop_to_content(img)
+        assert result.size == img.size
+
+    def test_crops_transparent_border(self):
+        arr = np.zeros((10, 10, 4), dtype=np.uint8)
+        arr[3:7, 2:8] = [255, 0, 0, 255]
+        img = Image.fromarray(arr)
+        cropped = crop_to_content(img)
+        assert cropped.width == 6
+        assert cropped.height == 4
+
+    def test_non_rgba_image_returned_unchanged(self):
+        arr = np.full((5, 5, 3), 128, dtype=np.uint8)
+        img = Image.fromarray(arr)
+        result = crop_to_content(img)
+        assert result is img
+
+    def test_single_pixel_content(self):
+        arr = np.zeros((10, 10, 4), dtype=np.uint8)
+        arr[5, 5] = [255, 255, 255, 255]
+        img = Image.fromarray(arr)
+        cropped = crop_to_content(img)
+        assert cropped.size == (1, 1)
+
+    def test_output_mode_is_rgba(self):
+        img = _rgba(4, 4, (0, 255, 0, 255))
+        result = crop_to_content(img)
+        assert result.mode == "RGBA"


### PR DESCRIPTION
## Summary
- Tests `tensor_to_pil`: RGB/RGBA input mode detection, size (h,w) mapping, value scaling 0–1→0–255, black/white edge cases, alpha channel preservation
- Tests `pil_to_tensor`: float32 dtype, output shape `(1, h, w, 4)`, RGB→RGBA conversion, values in [0,1], RGBA alpha preservation, h/w dimension order
- Tests `SpriteGrid` node metadata: `RETURN_TYPES`, `FUNCTION`, `CATEGORY`, `INPUT_TYPES()` structure, `min_grid`/`quantize` defaults, `remove_background` choices, `crop` default
- Tests `NODE_CLASS_MAPPINGS` and `NODE_DISPLAY_NAME_MAPPINGS` dictionaries

No ComfyUI runtime required — tests exercise the pure tensor/image conversion logic and metadata dictionaries only.  
Run with `uv run --with torch pytest tests/test_comfyui_nodes.py` (torch not in project deps but available as a system package).

## Test plan
- [x] All 29 tests pass with `uv run --with torch pytest tests/test_comfyui_nodes.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)