### PR TITLE
ci: add pytest workflow + skip comfyui test when torch missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: pytest
+
+on:
+  push:
+    branches: "main"
+  pull_request:
+    branches: "*"
+
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv python install 3.13
+      - run: uv sync
+      - run: uv run --with pytest pytest -vv

--- a/tests/test_comfyui_nodes.py
+++ b/tests/test_comfyui_nodes.py
@@ -7,8 +7,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import torch
 from PIL import Image
+
+torch = pytest.importorskip("torch")
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` modelled on the `pytest.yml` in `syntk`/`dhlab-mcp` (uv-driven, runs on push to main + every PR).
- Fixes `tests/test_comfyui_nodes.py` which imported `torch` unconditionally even though `torch` isn't a project dependency — pytest collection failed in any env without torch installed. Now skips cleanly via `pytest.importorskip("torch")`.

## Test plan
- [x] `uv run --with pytest pytest -q` → `76 passed, 1 skipped, 27 warnings in 5.75s`
- [ ] CI green on this PR