### PR TITLE
fix(comfyui): drop deprecated mode= param from Image.fromarray

### DIFF
--- a/src/spritegrid/comfyui/nodes.py
+++ b/src/spritegrid/comfyui/nodes.py
@@ -18,9 +18,7 @@ def tensor_to_pil(tensor: torch.Tensor) -> Image.Image:
     """Convert ComfyUI IMAGE tensor to PIL Image."""
     img = tensor.squeeze(0).cpu().numpy()
     img = (img * 255).clip(0, 255).astype(np.uint8)
-    if img.shape[-1] == 4:
-        return Image.fromarray(img, mode="RGBA")
-    return Image.fromarray(img, mode="RGB")
+    return Image.fromarray(img)
 
 
 def pil_to_tensor(pil_img: Image.Image) -> torch.Tensor:


### PR DESCRIPTION
## Summary
Pillow 13 (2026-10-15) removes the `mode=` parameter from `Image.fromarray`. For uint8 arrays the mode is auto-detected from the last-axis shape (3 → RGB, 4 → RGBA), so the two branches collapse into a single `Image.fromarray(img)` call.

Closes #36.

## Test plan
- [x] `pytest tests/test_comfyui_nodes.py -v` → 29 passed, no deprecation warnings
- [ ] CI green on this PR