### PR TITLE
chore(tests): drop deprecated mode= positional arg from Image.fromarray

### DIFF
--- a/tests/test_background_removal.py
+++ b/tests/test_background_removal.py
@@ -30,7 +30,7 @@ def test_crop_to_content():
     ]  # Red with alpha=255
 
     # Convert numpy array to PIL Image
-    test_image = Image.fromarray(draw_area, "RGBA")
+    test_image = Image.fromarray(draw_area)
 
     # Apply cropping
     cropped = crop_to_content(test_image)

--- a/tests/test_cli_crop_scale.py
+++ b/tests/test_cli_crop_scale.py
@@ -12,7 +12,7 @@ def create_test_image(path, size=(200, 200), content_rect=(50, 50, 150, 150)):
     img_array = np.zeros((size[1], size[0], 4), dtype=np.uint8)
     left, top, right, bottom = content_rect
     img_array[top:bottom, left:right] = [255, 100, 100, 255]
-    img = Image.fromarray(img_array, "RGBA")
+    img = Image.fromarray(img_array)
     img.save(path)
     return path
 

--- a/tests/test_crop_and_scale.py
+++ b/tests/test_crop_and_scale.py
@@ -22,7 +22,7 @@ def create_test_image_with_content(
     img_array = np.zeros((height, width, 4), dtype=np.uint8)
     left, top, right, bottom = content_rect
     img_array[top:bottom, left:right] = color
-    return Image.fromarray(img_array, "RGBA")
+    return Image.fromarray(img_array)
 
 
 def test_detect_bounds():

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -35,9 +35,9 @@ def create_test_image(img_w, img_h, grid_w, grid_h, color=False, noise_level=0):
     if color:
         # Stack grayscale array to create RGB
         array_rgb = np.stack([array] * 3, axis=-1)
-        return Image.fromarray(array_rgb, "RGB")
+        return Image.fromarray(array_rgb)
     else:
-        return Image.fromarray(array, "L")
+        return Image.fromarray(array)
 
 
 def test_detect_grid():

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -126,7 +126,7 @@ class TestCreateDownsampledImage:
         w = grid_w * cells_w
         h = grid_h * cells_h
         arr = np.zeros((h, w, 3), dtype=np.uint8)
-        return Image.fromarray(arr, "RGB")
+        return Image.fromarray(arr)
 
     def test_output_size_matches_num_cells(self):
         from spritegrid.main import create_downsampled_image


### PR DESCRIPTION
Companion to #38 (which fixed the same Pillow 13 deprecation in src/spritegrid/comfyui/nodes.py). Tests still passed the deprecated `mode=` string positionally in 7 places. For uint8 arrays Pillow auto-detects the mode from the array shape (2D → L, hxwx3 → RGB, hxwx4 → RGBA), so the arg is redundant.

Files touched: test_main_utils, test_cli_crop_scale, test_background_removal, test_detection (×2), test_crop_and_scale.

## Test plan
- [x] `uv run --with pytest pytest -q -W error::DeprecationWarning` → 158 passed, 0 DeprecationWarnings
- [ ] CI green