### PR TITLE
fix(segmentation): --debug image was 'RGB' from ARGB bytes — color-shifted + truncated

### DIFF
--- a/src/spritegrid/segmentation.py
+++ b/src/spritegrid/segmentation.py
@@ -77,10 +77,16 @@ def make_background_transparent(
             show_mask(mask, ax=ax, random_color=True)
         plt.axis("off")
 
-        # Convert the matplotlib figure to a PIL image
+        # Convert the matplotlib figure to a PIL image.
+        # fig.canvas.tostring_argb() returns ARGB bytes (4 bytes/pixel) — feeding
+        # those to Image.frombytes("RGB", ...) silently misinterpreted them as
+        # RGB (3 bytes/pixel), producing a color-shifted, bottom-truncated debug
+        # image (every visible pixel offset by one channel; the last quarter
+        # filled with garbage / black). Use buffer_rgba() so the byte format
+        # matches what PIL is told to parse.
         fig.canvas.draw()
         debug_image = Image.frombytes(
-            "RGB", fig.canvas.get_width_height(), fig.canvas.tostring_argb()
+            "RGBA", fig.canvas.get_width_height(), bytes(fig.canvas.buffer_rgba())
         )
         plt.close(fig)  # Close the figure to free memory
 

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -139,3 +139,28 @@ class TestMakeBackgroundTransparent:
         img = Image.fromarray(np.full((6, 6, 3), [128, 128, 128], dtype=np.uint8))
         out_img, debug = make_background_transparent(img)
         assert isinstance(out_img, Image.Image)
+
+    def test_debug_image_byte_length_matches_canvas(self):
+        """Regression: the debug image was built by feeding 4-byte/pixel ARGB
+        bytes (fig.canvas.tostring_argb()) into Image.frombytes('RGB', ...),
+        which interprets 3 bytes/pixel — silently producing a color-shifted,
+        bottom-truncated picture. After the fix the byte count must be
+        consistent with the declared mode (4 bytes/pixel RGBA)."""
+        from unittest.mock import patch
+        from spritegrid import segmentation
+
+        # Mock the cluster labels so the debug path runs deterministically
+        # without depending on DBSCAN being able to find clusters in noise.
+        arr = np.zeros((8, 8, 3), dtype=np.uint8)
+        labels = np.zeros((8, 8), dtype=np.int64)
+        labels[:4, :] = 0
+        labels[4:, :] = 1
+        with patch.object(segmentation, "generate_segment_masks", return_value=labels):
+            img = Image.fromarray(arr)
+            _, debug_img = segmentation.make_background_transparent(img, debug=True)
+        assert debug_img is not None
+        # The fix uses 'RGBA' (4 bytes/pixel), matching canvas.buffer_rgba()
+        assert debug_img.mode == "RGBA"
+        w, h = debug_img.size
+        # The raw bytes from the underlying buffer must be exactly w*h*4
+        assert len(debug_img.tobytes()) == w * h * 4


### PR DESCRIPTION
## Bug

\`make_background_transparent(debug=True)\` (\`segmentation.py:82-84\`) constructed the debug image with:

\`\`\`python
debug_image = Image.frombytes(
    \"RGB\", fig.canvas.get_width_height(), fig.canvas.tostring_argb()
)
\`\`\`

But \`tostring_argb\` returns **4 bytes/pixel** (ARGB), and \`Image.frombytes(\"RGB\", ...)\` interprets the buffer as **3 bytes/pixel**. PIL doesn't error here — it silently:

- reads the first 3/4 of the ARGB buffer (truncating the bottom of the image to ~75 % canvas height as black / garbage)
- interprets bytes as RGB tuples that walk forward by one channel each pixel, so every visible pixel's color is wrong and the channels drift over the image

The bug ships through to \`main.py:493\` (the \`spritegrid --debug\` flag), so users running the debug overlay get a corrupted image without any error.

## Fix

Switch to \`fig.canvas.buffer_rgba()\` + mode \`\"RGBA\"\` so the byte format matches what we tell PIL:

\`\`\`python
debug_image = Image.frombytes(
    \"RGBA\", fig.canvas.get_width_height(), bytes(fig.canvas.buffer_rgba())
)
\`\`\`

## Test

\`test_debug_image_byte_length_matches_canvas\` — mocks \`generate_segment_masks\` so the test doesn't depend on DBSCAN finding clusters in noise, then verifies the resulting debug image is RGBA mode with the expected w*h*4 byte length.

158 → 159 tests, all green.