### PR TITLE
feat: add grid translation (--offset, --auto-offset) — re-land of #26 [1/2]

### DIFF
--- a/src/spritegrid/cli.py
+++ b/src/spritegrid/cli.py
@@ -1,6 +1,6 @@
 import argparse
 import sys
-from typing import Optional, Tuple
+from typing import Tuple
 
 from .main import main
 
@@ -155,6 +155,29 @@ def parse_args() -> argparse.Namespace:
         help="Output a side-by-side before/after comparison image instead of just the result.",
     )
 
+    parser.add_argument(
+        "--offset",
+        type=parse_size,
+        metavar="XxY",
+        default=None,
+        help=(
+            "Manually translate the grid origin by X,Y pixels (e.g. '2x3'). "
+            "Shifts all sample centres right by X and down by Y. "
+            "Overrides --auto-offset."
+        ),
+    )
+
+    parser.add_argument(
+        "--auto-offset",
+        action="store_true",
+        default=False,
+        help=(
+            "Auto-detect the grid phase offset from the gradient profile and apply it. "
+            "Improves alignment when the grid does not start at pixel 0. "
+            "Ignored when --offset is specified."
+        ),
+    )
+
     args = parser.parse_args()
 
     # Ensure the crop argument is passed correctly
@@ -184,6 +207,8 @@ def cli() -> None:
         res=args.res,
         aspect_ratio=args.aspectratio,
         compare=args.compare,
+        offset=args.offset,
+        auto_offset=args.auto_offset,
     )
 
 
@@ -284,7 +309,6 @@ def crop_scale_cli() -> None:
     """
     Entry point for the crop-and-scale command line interface.
     """
-    from PIL import Image
     from .main import load_image, handle_output
     from .crop_and_scale import crop_and_scale, crop_and_scale_centered
 

--- a/src/spritegrid/detection.py
+++ b/src/spritegrid/detection.py
@@ -76,6 +76,35 @@ def find_dominant_spacing(
     return int(most_common_spacing), confidence
 
 
+def find_grid_offset(profile: np.ndarray, spacing: int) -> int:
+    """Find the phase offset of a repeating grid pattern in a 1D gradient profile.
+
+    Scans offset values 0..(spacing-1) and returns the one that maximises the
+    sum of profile values at positions offset, offset+spacing, offset+2*spacing, ...
+
+    Args:
+        profile: 1D gradient profile.
+        spacing: Known grid cell size in pixels.
+
+    Returns:
+        Best offset (0-indexed pixel position where the first grid line falls).
+    """
+    if spacing <= 0 or len(profile) < spacing:
+        return 0
+
+    best_offset = 0
+    best_score = -1.0
+
+    for offset in range(spacing):
+        indices = np.arange(offset, len(profile), spacing)
+        score = float(profile[indices].sum())
+        if score > best_score:
+            best_score = score
+            best_offset = offset
+
+    return best_offset
+
+
 def detect_grid(
     image: Image.Image,
     min_grid_size: int = 4,
@@ -96,6 +125,34 @@ def detect_grid(
 
     Returns:
         Tuple (grid_w, grid_h) or (0, 0) if detection fails or confidence is low.
+    """
+    result = detect_grid_with_offset(image, min_grid_size, smoothing_sigma, min_confidence)
+    return result[0], result[1]
+
+
+def detect_grid_with_offset(
+    image: Image.Image,
+    min_grid_size: int = 4,
+    smoothing_sigma: float = 1.0,
+    min_confidence: float = 0.4,
+) -> Tuple[int, int, int, int]:
+    """
+    Analyzes the input image to detect grid dimensions *and* the phase offset.
+
+    Returns (grid_w, grid_h, offset_x, offset_y).  The offset tells you the
+    x/y pixel position where the first grid column/row boundary falls.
+    Use the half-cell shift (offset_x + grid_w//2) as the first sample centre.
+
+    Returns (0, 0, 0, 0) if no reliable grid is detected.
+
+    Args:
+        image: The PIL Image object to analyze.
+        min_grid_size: Minimum expected grid dimension for peak finding.
+        smoothing_sigma: Gaussian smoothing sigma (0 to disable).
+        min_confidence: Minimum confidence threshold (0-1) to accept detection.
+
+    Returns:
+        Tuple (grid_w, grid_h, offset_x, offset_y) or (0, 0, 0, 0).
     """
     try:
         # Convert to grayscale
@@ -130,7 +187,7 @@ def detect_grid(
 
         # Check if detection failed
         if grid_w <= 0 or grid_h <= 0:
-            return (0, 0)
+            return (0, 0, 0, 0)
 
         # Check confidence threshold
         avg_confidence = (conf_h + conf_w) / 2
@@ -140,7 +197,7 @@ def detect_grid(
                 "Image may already be clean pixel art.",
                 file=sys.stderr,
             )
-            return (0, 0)
+            return (0, 0, 0, 0)
 
         # Check grid aspect ratio - genuine pixel art grids are roughly square
         grid_ratio = grid_w / grid_h
@@ -150,17 +207,21 @@ def detect_grid(
                 "Image may already be clean pixel art.",
                 file=sys.stderr,
             )
-            return (0, 0)
+            return (0, 0, 0, 0)
 
-        return grid_w, grid_h
+        # Detect grid phase offset using the already-computed gradient profiles
+        offset_x = find_grid_offset(profile_h, grid_w)
+        offset_y = find_grid_offset(profile_v, grid_h)
+
+        return grid_w, grid_h, offset_x, offset_y
 
     except ImportError:
         print(
             "Error: SciPy or NumPy not found. Install with: pip install numpy scipy pillow",
             file=sys.stderr,
         )
-        return (0, 0)
+        return (0, 0, 0, 0)
     except Exception as e:
         print(f"Grid detection error: {e}", file=sys.stderr)
         traceback.print_exc()
-        return (0, 0)
+        return (0, 0, 0, 0)

--- a/src/spritegrid/main.py
+++ b/src/spritegrid/main.py
@@ -7,7 +7,7 @@ from PIL import Image, ImageDraw
 
 from spritegrid.segmentation import make_background_transparent
 
-from .detection import detect_grid
+from .detection import detect_grid_with_offset
 from .utils import (
     convert_image_to_ascii,
     geometric_median,
@@ -89,6 +89,8 @@ def create_downsampled_image(
     bit: int = 8,
     kernel_size: tuple = (3, 3),
     median_type: str = "naive",
+    offset_x: int = 0,
+    offset_y: int = 0,
 ) -> Image.Image:
     """
     Creates a new image by sampling the geometric median pixel of each grid cell
@@ -102,6 +104,8 @@ def create_downsampled_image(
         num_cells_h: The number of grid cells vertically.
         bit: Number of bits per color channel.
         kernel_size: Size of the kernel to sample from (width, height).
+        offset_x: Horizontal grid translation in pixels (shifts sample centres right).
+        offset_y: Vertical grid translation in pixels (shifts sample centres down).
 
     Returns:
         A new PIL Image object with dimensions (num_cells_w, num_cells_h).
@@ -155,9 +159,9 @@ def create_downsampled_image(
 
     for y_new in range(num_cells_h):
         for x_new in range(num_cells_w):
-            # Calculate center coordinates in the original image
-            center_x = min(int(x_new * grid_w + grid_w / 2), original_width - 1)
-            center_y = min(int(y_new * grid_h + grid_h / 2), original_height - 1)
+            # Calculate center coordinates in the original image, applying grid offset
+            center_x = min(max(0, int(x_new * grid_w + grid_w / 2) + offset_x), original_width - 1)
+            center_y = min(max(0, int(y_new * grid_h + grid_h / 2) + offset_y), original_height - 1)
 
             # Calculate kernel boundaries
             half_kernel_w = kernel_w // 2
@@ -407,6 +411,8 @@ def main(
     res: Optional[Tuple[int, int]] = None,
     aspect_ratio: Optional[Tuple[int, int]] = None,
     compare: bool = False,
+    offset: Optional[Tuple[int, int]] = None,
+    auto_offset: bool = False,
 ) -> None:
     """
     Main function to parse arguments, load image, detect grid, and generate output/debug image.
@@ -437,7 +443,20 @@ def main(
     )
 
     # Call the grid detection function from the detection module
-    detected_w, detected_h = detect_grid(image, min_grid_size=min_grid)
+    detected_w, detected_h, auto_offset_x, auto_offset_y = detect_grid_with_offset(
+        image, min_grid_size=min_grid
+    )
+
+    # Apply manual offset if provided; auto-detected offset only if --auto-offset is set
+    if offset is not None:
+        offset_x, offset_y = offset
+        print(f"Using manual grid offset: ({offset_x}, {offset_y})")
+    elif auto_offset:
+        offset_x, offset_y = auto_offset_x, auto_offset_y
+        if detected_w > 0 and (offset_x != 0 or offset_y != 0):
+            print(f"Auto-detected grid offset: ({offset_x}, {offset_y})")
+    else:
+        offset_x, offset_y = 0, 0
 
     # Check the results returned by detect_grid
     if detected_w > 0 and detected_h > 0:
@@ -484,6 +503,8 @@ def main(
                 num_cells_w,
                 num_cells_h,
                 quantize,
+                offset_x=offset_x,
+                offset_y=offset_y,
             )
 
             if remove_background == "after":

--- a/tests/test_grid_translation.py
+++ b/tests/test_grid_translation.py
@@ -1,0 +1,209 @@
+"""Tests for grid translation (offset) and phase detection."""
+
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image
+
+from spritegrid.detection import find_grid_offset, detect_grid_with_offset
+from spritegrid.main import create_downsampled_image
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_grid_image(cell_size: int, cells_w: int, cells_h: int,
+                     offset_x: int = 0, offset_y: int = 0) -> Image.Image:
+    """Create a synthetic pixel-art-style image with a regular repeating grid.
+
+    Each cell has a unique solid colour so that sample points inside vs on the
+    boundary of a cell produce different results.  The grid lines (1px wide) are
+    black; cell interiors are mid-grey (128).  Offset shifts the grid right/down.
+    """
+    w = cells_w * cell_size + offset_x
+    h = cells_h * cell_size + offset_y
+    arr = np.full((h, w, 3), 128, dtype=np.uint8)
+
+    # Draw vertical lines at offset_x, offset_x+cell_size, ...
+    for x in range(offset_x, w, cell_size):
+        arr[:, x, :] = 0
+
+    # Draw horizontal lines at offset_y, offset_y+cell_size, ...
+    for y in range(offset_y, h, cell_size):
+        arr[y, :, :] = 0
+
+    return Image.fromarray(arr, "RGB")
+
+
+def _uniform_image(w: int, h: int, color=(128, 128, 128)) -> Image.Image:
+    arr = np.full((h, w, 3), color, dtype=np.uint8)
+    return Image.fromarray(arr, "RGB")
+
+
+# ---------------------------------------------------------------------------
+# find_grid_offset
+# ---------------------------------------------------------------------------
+
+class TestFindGridOffset:
+    def test_zero_spacing_returns_zero(self):
+        profile = np.array([0.0, 1.0, 0.0, 1.0])
+        assert find_grid_offset(profile, 0) == 0
+
+    def test_empty_profile_returns_zero(self):
+        assert find_grid_offset(np.array([]), 4) == 0
+
+    def test_profile_shorter_than_spacing_returns_zero(self):
+        assert find_grid_offset(np.array([1.0, 2.0]), 10) == 0
+
+    def test_finds_peak_position(self):
+        spacing = 8
+        n = 64
+        profile = np.zeros(n)
+        # Put peaks at positions 3, 11, 19, 27, ... (offset=3)
+        for pos in range(3, n, spacing):
+            profile[pos] = 100.0
+        result = find_grid_offset(profile, spacing)
+        assert result == 3
+
+    def test_zero_offset(self):
+        spacing = 4
+        n = 32
+        profile = np.zeros(n)
+        for pos in range(0, n, spacing):
+            profile[pos] = 50.0
+        result = find_grid_offset(profile, spacing)
+        assert result == 0
+
+    def test_offset_at_spacing_minus_one(self):
+        spacing = 5
+        n = 50
+        profile = np.zeros(n)
+        offset = spacing - 1  # = 4
+        for pos in range(offset, n, spacing):
+            profile[pos] = 75.0
+        result = find_grid_offset(profile, spacing)
+        assert result == offset
+
+    def test_returns_value_in_range(self):
+        spacing = 6
+        profile = np.random.default_rng(42).random(60)
+        result = find_grid_offset(profile, spacing)
+        assert 0 <= result < spacing
+
+
+# ---------------------------------------------------------------------------
+# detect_grid_with_offset
+# ---------------------------------------------------------------------------
+
+class TestDetectGridWithOffset:
+    def test_returns_4_tuple(self):
+        img = _make_grid_image(cell_size=8, cells_w=10, cells_h=10)
+        result = detect_grid_with_offset(img)
+        assert len(result) == 4
+
+    def test_zero_on_failed_detection(self):
+        img = _uniform_image(64, 64)
+        result = detect_grid_with_offset(img)
+        assert result == (0, 0, 0, 0)
+
+    def test_grid_dimensions_match_detect_grid(self):
+        from spritegrid.detection import detect_grid
+        img = _make_grid_image(cell_size=8, cells_w=10, cells_h=10)
+        gw, gh = detect_grid(img)
+        gw2, gh2, ox, oy = detect_grid_with_offset(img)
+        assert gw == gw2
+        assert gh == gh2
+
+    def test_offset_is_in_valid_range(self):
+        img = _make_grid_image(cell_size=8, cells_w=10, cells_h=10)
+        gw, gh, ox, oy = detect_grid_with_offset(img)
+        if gw > 0:
+            assert 0 <= ox < gw
+            assert 0 <= oy < gh
+
+
+# ---------------------------------------------------------------------------
+# create_downsampled_image — offset parameter
+# ---------------------------------------------------------------------------
+
+class TestCreateDownsampledImageOffset:
+    def _solid_image(self, w: int, h: int, color=(200, 100, 50)) -> Image.Image:
+        arr = np.full((h, w, 3), color, dtype=np.uint8)
+        return Image.fromarray(arr, "RGB")
+
+    def test_zero_offset_matches_default(self):
+        img = self._solid_image(16, 16)
+        r1 = create_downsampled_image(img, 4, 4, 4, 4)
+        r2 = create_downsampled_image(img, 4, 4, 4, 4, offset_x=0, offset_y=0)
+        assert list(r1.getdata()) == list(r2.getdata())
+
+    def test_offset_does_not_raise(self):
+        img = self._solid_image(32, 32)
+        # With a solid image any offset produces the same colour
+        result = create_downsampled_image(img, 4, 4, 8, 8, offset_x=2, offset_y=2)
+        assert result.size == (8, 8)
+
+    def test_positive_offset_clamps_to_image_bounds(self):
+        img = self._solid_image(16, 16)
+        # Large offset — should clamp rather than raise
+        result = create_downsampled_image(img, 4, 4, 4, 4, offset_x=100, offset_y=100)
+        assert result.size == (4, 4)
+
+    def test_negative_offset_clamps_to_image_bounds(self):
+        img = self._solid_image(16, 16)
+        result = create_downsampled_image(img, 4, 4, 4, 4, offset_x=-100, offset_y=-100)
+        assert result.size == (4, 4)
+
+    def test_offset_shifts_sample_position(self):
+        """Verify that a non-zero offset actually changes the sampled pixel values."""
+        # Left half: red, right half: blue — a 1px offset should change sampled colours
+        # for some cells near the boundary
+        arr = np.zeros((8, 16, 3), dtype=np.uint8)
+        arr[:, :8, 0] = 255   # red left
+        arr[:, 8:, 2] = 255   # blue right
+        img = Image.fromarray(arr, "RGB")
+
+        # Cell size 8, 2 cells wide → boundary falls right on x=8
+        r_no_offset = create_downsampled_image(img, 8, 8, 2, 1, offset_x=0, offset_y=0)
+        r_with_offset = create_downsampled_image(img, 8, 8, 2, 1, offset_x=4, offset_y=0)
+
+        # With offset=4: first cell centre is at x=8, second at x=16 (clamped to 15)
+        # Without offset: first cell centre is at x=4 (red), second at x=12 (blue)
+        # They should differ
+        assert list(r_no_offset.getdata()) != list(r_with_offset.getdata())
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — --offset and --auto-offset flags
+# ---------------------------------------------------------------------------
+
+class TestCliOffsetArgs:
+    def test_offset_parsed(self, tmp_path):
+        import subprocess
+        import sys
+        img = _solid = _make_grid_image(4, 8, 8)
+        src = tmp_path / "in.png"
+        out = tmp_path / "out.png"
+        img.save(src)
+        result = subprocess.run(
+            [sys.executable, "-m", "spritegrid", str(src), "-o", str(out),
+             "--offset", "2x2"],
+            capture_output=True, text=True,
+        )
+        # Should not error on argument parsing
+        assert result.returncode == 0 or "error" not in result.stderr.lower().split("offset")[0]
+
+    def test_auto_offset_flag(self, tmp_path):
+        import subprocess
+        import sys
+        img = _make_grid_image(4, 8, 8)
+        src = tmp_path / "in.png"
+        out = tmp_path / "out.png"
+        img.save(src)
+        result = subprocess.run(
+            [sys.executable, "-m", "spritegrid", str(src), "-o", str(out),
+             "--auto-offset"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0 or "error" not in result.stderr.lower()


### PR DESCRIPTION
**Draft re-land of part 1 of #26** — hai-pilgrim's PR mixed 3 unrelated commits (offset+translation feature, --res/--aspectratio flags, a hallucinated "Pillow deprecation" fix). Landing them separately.

- ✅ This PR — `daa5361` (--offset / --auto-offset)
- ⏭ `e3c03d7` (--res / --aspectratio) — already on main, presumably landed via a different PR while this was open
- ❌ `d57d742` ("fix deprecated getdata()" → `get_flattened_data()`) — **bogus**. `get_flattened_data` is not a real PIL Image method (`hasattr` returns False on Pillow 11.3); `getdata` is not deprecated. Cherry-picking would AttributeError every test it touches. Skipped.

## Summary
Adds two ways to control where the grid origin sits, useful when the detected grid doesn't start at pixel 0:
- `--offset XxY` — manually translate sample-centre grid by X,Y pixels
- `--auto-offset` — auto-detect the grid phase offset from the gradient profile

`create_downsampled_image` gains optional `offset_x`/`offset_y` kwargs. `detect_grid_with_offset` wraps `detect_grid` + `find_grid_offset`.

Refs #6 (the broader "grid translation + multi-grid segments" issue — this lands the translation half).

## Test plan
- [x] 177 tests pass (`pytest -q --ignore=tests/test_comfyui_nodes.py`)
- [x] argparse / cli conflict resolved by keeping both `--compare` (HEAD) AND `--offset`/`--auto-offset` (PR)
- [ ] CI / your review
