### PR TITLE
docs(readme): fix --offset syntax to match parse_size (XxY, not X,Y)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ spritegrid ai_pixelart.png -o sprite.png --aspectratio 4:3
 spritegrid ai_pixelart.png -o compare.png --compare
 
 # Translate the sample-centre grid by a fixed pixel offset, or auto-detect it
-spritegrid ai_pixelart.png -o sprite.png --offset 2,3
+spritegrid ai_pixelart.png -o sprite.png --offset 2x3
 spritegrid ai_pixelart.png -o sprite.png --auto-offset
 ```
 
@@ -118,7 +118,7 @@ spritegrid ai_pixelart.png -o sprite.png --auto-offset
 | `--res WxH` | Force exact output resolution, e.g. `32x32` (NEAREST; overrides `--aspectratio`) |
 | `--aspectratio W:H` | Center-crop output to an aspect ratio, e.g. `4:3` |
 | `--compare` | Output a side-by-side before/after comparison image |
-| `--offset X,Y` | Manually translate the sample-centre grid by `X,Y` pixels |
+| `--offset XxY` | Manually translate the sample-centre grid by `X,Y` pixels (e.g. `2x3`) |
 | `--auto-offset` | Auto-detect the grid phase offset from the gradient profile |
 
 ### Sprite Extraction


### PR DESCRIPTION
The `--offset` flag landed in #44 using `parse_size` (same helper as `--res`, `--size`), which only accepts `XxY` format. The README documented it as `X,Y` (comma) — would fail at parse-time with `Invalid size format: 2,3`.

Two example lines + one flags-table row updated. Now consistent with `--res`/`--size`/`--aspectratio`.

Flagged on #44 before merge; picking the README-update side since aligning with sibling flags is the more predictable UX.
