### PR TITLE
fix(detection): detect_grid_with_offset returned 2-tuple on too-small images

### DIFF
--- a/src/spritegrid/detection.py
+++ b/src/spritegrid/detection.py
@@ -166,7 +166,7 @@ def detect_grid_with_offset(
 
         # Image too small for analysis
         if img_h < actual_min_spacing * 2 or img_w < actual_min_spacing * 2:
-            return (0, 0)
+            return (0, 0, 0, 0)
 
         # Calculate gradients
         gradient_h = np.abs(np.diff(img_array, axis=1, append=img_array[:, -1:]))

--- a/tests/test_detection_extra.py
+++ b/tests/test_detection_extra.py
@@ -6,7 +6,11 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from spritegrid.detection import find_dominant_spacing, detect_grid
+from spritegrid.detection import (
+    find_dominant_spacing,
+    detect_grid,
+    detect_grid_with_offset,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -129,3 +133,29 @@ class TestDetectGrid:
             gw, gh = detect_grid(img)
             assert gw >= 0
             assert gh >= 0
+
+
+# ---------------------------------------------------------------------------
+# detect_grid_with_offset — must always honour its 4-tuple contract
+# ---------------------------------------------------------------------------
+
+class TestDetectGridWithOffset:
+    def test_always_returns_four_tuple(self):
+        img = _uniform_image(64, 64)
+        result = detect_grid_with_offset(img)
+        assert isinstance(result, tuple)
+        assert len(result) == 4
+
+    def test_too_small_image_returns_four_zeros(self):
+        """Regression: a too-small image must return (0, 0, 0, 0), not (0, 0).
+
+        main.py unpacks four values, so a 2-tuple here raised
+        'ValueError: not enough values to unpack'.
+        """
+        img = Image.new("L", (4, 4), 128)
+        w, h, ox, oy = detect_grid_with_offset(img, min_grid_size=8)
+        assert (w, h, ox, oy) == (0, 0, 0, 0)
+
+    def test_uniform_image_returns_four_zeros(self):
+        img = _uniform_image(64, 64)
+        assert detect_grid_with_offset(img) == (0, 0, 0, 0)


### PR DESCRIPTION
## Summary
`detect_grid_with_offset` returned `(0, 0)` from its too-small-image guard, but the function contract (and every direct caller — `main.py` unpacks four values) expects a 4-tuple `(grid_w, grid_h, offset_x, offset_y)`. A tiny input crashed with:

```
ValueError: not enough values to unpack (expected 4, got 2)
```

The `detect_grid` wrapper masked this because it only reads `result[0], result[1]`, so the existing too-small test passed despite the bug.

## Fix
- Return `(0, 0, 0, 0)` from the guard.
- Add `TestDetectGridWithOffset` regression tests asserting the 4-tuple contract (too-small, uniform, and general cases).

## Test plan
- [x] `pytest tests/test_detection_extra.py` — 17 passed (3 new)
- [x] Full suite green locally

Part of #47.