### PR TITLE
chore(tests): drop deprecated Image.fromarray mode= arg in test_grid_translation

### DIFF
--- a/tests/test_grid_translation.py
+++ b/tests/test_grid_translation.py
@@ -33,12 +33,12 @@ def _make_grid_image(cell_size: int, cells_w: int, cells_h: int,
     for y in range(offset_y, h, cell_size):
         arr[y, :, :] = 0
 
-    return Image.fromarray(arr, "RGB")
+    return Image.fromarray(arr)
 
 
 def _uniform_image(w: int, h: int, color=(128, 128, 128)) -> Image.Image:
     arr = np.full((h, w, 3), color, dtype=np.uint8)
-    return Image.fromarray(arr, "RGB")
+    return Image.fromarray(arr)
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +130,7 @@ class TestDetectGridWithOffset:
 class TestCreateDownsampledImageOffset:
     def _solid_image(self, w: int, h: int, color=(200, 100, 50)) -> Image.Image:
         arr = np.full((h, w, 3), color, dtype=np.uint8)
-        return Image.fromarray(arr, "RGB")
+        return Image.fromarray(arr)
 
     def test_zero_offset_matches_default(self):
         img = self._solid_image(16, 16)
@@ -162,7 +162,7 @@ class TestCreateDownsampledImageOffset:
         arr = np.zeros((8, 16, 3), dtype=np.uint8)
         arr[:, :8, 0] = 255   # red left
         arr[:, 8:, 2] = 255   # blue right
-        img = Image.fromarray(arr, "RGB")
+        img = Image.fromarray(arr)
 
         # Cell size 8, 2 cells wide → boundary falls right on x=8
         r_no_offset = create_downsampled_image(img, 8, 8, 2, 1, offset_x=0, offset_y=0)


### PR DESCRIPTION
## Summary
Removes the last in-repo uses of the deprecated `Image.fromarray(arr, "RGB")` positional mode arg (removed in Pillow 13, 2026-10-15), in `test_grid_translation.py`. `fromarray` infers `RGB` from the `(H, W, 3)` array shape, so the arg is redundant. Mirrors the cleanup in #42.

## Result
- Suite warning count: 18 → 7.
- The 7 remaining `DeprecationWarning`s all originate from matplotlib's internal `_backend_tk.py` (`Image.fromarray(image_data, mode="RGBA")`), triggered by the segmentation debug test — upstream, not fixable here.

## Test plan
- [x] `pytest` — 189 passed, 1 skipped
- [x] `pytest -W error::DeprecationWarning` — only the matplotlib-internal warning remains

Part of #47.