### PR TITLE
ci: bump actions off deprecated Node 20

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install 3.13
       - run: uv sync
       - run: uv run --with pytest pytest -vv


### PR DESCRIPTION
## Summary
GitHub is forcing several actions onto Node 24 due to the Node 20 deprecation (warning observed on recent CI runs). Bump them to current majors (all verified to exist):

- `test.yml`: `actions/checkout@v4 → v5`, `astral-sh/setup-uv@v5 → v6`
- `publish-pypi.yml`: `actions/checkout@v3 → v5`, `actions/setup-python@v4 → v5`

Left unchanged: `pypa/gh-action-pypi-publish@v1` (Docker-based, unaffected by the Node deprecation) and the existing PyPI token auth (migrating to trusted publishing needs PyPI-side config — out of scope).

## Test plan
- [x] Verified `checkout@v5`, `setup-uv@v6`, `setup-python@v5` tags exist via the GitHub API.
- [x] `test.yml` exercised by this PR's CI run.
- Note: `publish-pypi.yml` only runs on `release: published`, so it is not exercised here; changes are limited to standard action-version bumps.

Closes the CI item in #47.