### PR TITLE
chore(packaging): declare requires-python >=3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "spritegrid"
 version = "0.2.0"
 description = "A command line tool for turning AI-generated pixel art into real pixel art."
 readme = "README.md"
-# requires-python = ">=3.9"
+requires-python = ">=3.12"
 dependencies = [
     "matplotlib>=3.10.1",
     "onnxruntime>=1.23.2",


### PR DESCRIPTION
## Summary
`requires-python` was commented out in `pyproject.toml`, so:
- the published package declares **no** minimum Python version, and
- uv prints `No requires-python value found in the workspace. Defaulting to >=3.12` on every invocation.

Meanwhile every other signal already targets 3.12:
- `.python-version` = `3.12`
- README badge = `Python 3.12+`
- CI installs `3.13`
- the code uses runtime-evaluated 3.10+ union syntax (e.g. `tuple[...]`, `Image.Image | None`) **without** `from __future__ import annotations`, so it genuinely won't import on <3.10.

This declares the already-true floor (`>=3.12`); it does not change supported behaviour. The old commented value (`>=3.9`) was inaccurate.

## Test plan
- [x] `uv run python -c "import spritegrid"` — imports cleanly, warning gone
- [x] `pytest` — 189 passed, 1 skipped

Part of #47.