### PR TITLE
feat: animation support — one shared grid across frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,14 @@ cp -r /path/to/spritegrid/src/spritegrid/comfyui \
   /path/to/ComfyUI/custom_nodes/spritegrid
 ```
 
-Restart ComfyUI after installing. The **SpriteGrid** node appears under `image/sprite`.
+Restart ComfyUI after installing. The **SpriteGrid** and **SpriteGrid (Animation)**
+nodes appear under `image/sprite`.
+
+For animation workflows (AnimateDiff, video frames, etc.), use **SpriteGrid
+(Animation)**: it takes an image *batch*, detects one shared grid across all
+frames, and downsamples each frame against it — so the cleaned animation stays
+temporally stable instead of flickering. (The plain **SpriteGrid** node detects
+per image and is intended for single frames.)
 
 ### Node Parameters
 
@@ -124,6 +131,41 @@ spritegrid ai_pixelart.png -o sprite.png --symmetric
 | `--compare` | Output a side-by-side before/after comparison image |
 | `--offset XxY` | Manually translate the sample-centre grid by `X,Y` pixels (e.g. `2x3`) |
 | `--auto-offset` | Auto-detect the grid phase offset from the gradient profile |
+| `--fps N` | Animation only: output frames-per-second (mutually exclusive with `--duration`) |
+| `--duration MS` | Animation only: milliseconds per frame (mutually exclusive with `--fps`) |
+
+### Animations
+
+SpriteGrid also cleans **animations** — animated GIF/APNG, a folder of numbered
+frames, or video (`.mp4` / `.webm`). The same `spritegrid` command auto-detects a
+multi-frame input and routes it through the animation pipeline; no separate
+command is needed.
+
+```bash
+# Clean an animated GIF (auto-detected) — output is also a GIF
+spritegrid character_walk.gif -o clean_walk.gif
+
+# A folder of frames in, a folder of frames out
+spritegrid frames_in/ -o frames_out/
+
+# Video in, video out, upscaled 8x and re-timed to 12 fps
+spritegrid anim.mp4 -o anim_clean.mp4 --res 256x256 --fps 12
+```
+
+The key difference from running each frame separately: SpriteGrid detects **one
+shared pixel grid across all frames** (by aggregating the per-frame gradient
+profiles) and downsamples every frame against that identical grid. Because grid
+lines sit at fixed positions while content moves, aggregating *reinforces* the
+grid and *averages out* the motion — so detection is robust and the output is
+temporally stable: every frame has the same resolution, the same grid
+alignment, and a shared palette (no flicker). All the still-image flags
+(`--min-grid`, `-q`, `--offset`/`--auto-offset`, `--res`, `--aspectratio`, `-c`,
+`-s`) apply per frame; `--crop` uses a single shared bounding box so the sprite
+size stays constant.
+
+> Video support uses OpenCV (already a dependency). `.mp4` (codec `mp4v`) is the
+> most portable output; tiny pixel-art frames encode best with an explicit
+> upscale, e.g. `--res 256x256`.
 
 ### Sprite Extraction
 

--- a/src/spritegrid/__init__.py
+++ b/src/spritegrid/__init__.py
@@ -28,6 +28,20 @@ from spritegrid.crop_and_scale import (
     crop_and_scale_centered,
     batch_process,
 )
+from spritegrid.detection import (
+    detect_grid,
+    detect_grid_with_offset,
+    detect_grid_across_frames,
+    compute_gradient_profiles,
+    detect_grid_from_profiles,
+)
+from spritegrid.animation import (
+    load_frames,
+    save_frames,
+    process_frames,
+    process_animation,
+    is_animated_source,
+)
 
 __all__ = [
     "process_sprite",
@@ -36,4 +50,16 @@ __all__ = [
     "crop_and_scale",
     "crop_and_scale_centered",
     "batch_process",
+    # Grid detection
+    "detect_grid",
+    "detect_grid_with_offset",
+    "detect_grid_across_frames",
+    "compute_gradient_profiles",
+    "detect_grid_from_profiles",
+    # Animation
+    "load_frames",
+    "save_frames",
+    "process_frames",
+    "process_animation",
+    "is_animated_source",
 ]

--- a/src/spritegrid/__main__.py
+++ b/src/spritegrid/__main__.py
@@ -1,0 +1,6 @@
+"""Enable ``python -m spritegrid`` to invoke the CLI (with animation auto-routing)."""
+
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/src/spritegrid/animation.py
+++ b/src/spritegrid/animation.py
@@ -1,0 +1,531 @@
+# animation.py
+"""Multi-frame (animation) support for SpriteGrid.
+
+The grid in AI-generated pixel art is a property of the *whole animation*, not
+of any single frame. Detecting it per frame makes the output resolution, grid
+phase, and palette jitter between frames, so the animation flickers and the
+frames no longer line up. This module detects ONE shared grid across all frames
+(see :func:`spritegrid.detection.detect_grid_across_frames`) and downsamples
+every frame against that identical lattice, so the cleaned animation is
+temporally stable.
+
+Supported I/O (all dependency-light; ``cv2`` is imported lazily only for video):
+    - animated GIF / APNG
+    - a directory of numbered PNG frames
+    - video (.mp4 / .webm / .mov / ...) via opencv
+"""
+
+import glob
+import os
+import re
+import sys
+
+import numpy as np
+from PIL import Image, ImageSequence
+
+from .detection import detect_grid_across_frames
+from .main import (
+    apply_aspect_ratio,
+    apply_resolution,
+    create_downsampled_image,
+    load_image,
+)
+from .utils import enforce_symmetry
+
+VIDEO_EXTS = (".mp4", ".webm", ".mov", ".avi", ".mkv", ".m4v")
+_FRAME_DIR_EXTS = (".png", ".gif", ".jpg", ".jpeg", ".webp", ".bmp")
+
+
+# --------------------------------------------------------------------------- #
+# Source classification                                                       #
+# --------------------------------------------------------------------------- #
+def is_animated_source(source: str) -> bool:
+    """Return True if *source* should be treated as a multi-frame animation.
+
+    True for: a local directory of frames, a video file (by extension), or an
+    animated image (GIF/APNG with >1 frame). Returns False for plain stills and
+    for anything that can't be cheaply inspected (e.g. remote URLs), so callers
+    fall back to the single-image path. Never raises.
+    """
+    try:
+        if isinstance(source, str) and os.path.isdir(source):
+            return True
+        if isinstance(source, str) and source.lower().endswith(VIDEO_EXTS):
+            return True
+        # Cheap local peek; avoid downloading remote URLs just to classify.
+        if isinstance(source, str) and source.startswith(("http://", "https://")):
+            return False
+        with Image.open(source) as img:
+            return bool(
+                getattr(img, "is_animated", False) and getattr(img, "n_frames", 1) > 1
+            )
+    except Exception:
+        return False
+
+
+def _natural_key(name: str):
+    """Sort key that orders ``frame2`` before ``frame10`` (numeric-aware)."""
+    return [
+        int(tok) if tok.isdigit() else tok.lower()
+        for tok in re.split(r"(\d+)", name)
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Loading                                                                     #
+# --------------------------------------------------------------------------- #
+def _import_cv2():
+    try:
+        import cv2  # noqa: PLC0415 (lazy: video path only)
+
+        return cv2
+    except ImportError as exc:  # pragma: no cover - opencv is a declared dep
+        raise ImportError(
+            "Video support requires opencv-python (cv2), which is a declared "
+            "spritegrid dependency. Reinstall with `uv sync` / `pip install opencv-python`."
+        ) from exc
+
+
+def _normalize_sizes(frames: list[Image.Image]) -> list[Image.Image]:
+    """Resize any odd-sized frames to match the first frame (NEAREST), with a warning.
+
+    Cross-frame grid detection sums per-frame profiles, which requires a common
+    frame size. Mild size drift (e.g. a hand-assembled frame folder) is repaired
+    here rather than rejected.
+    """
+    if not frames:
+        return frames
+    base = frames[0].size
+    mismatched = False
+    out = []
+    for frame in frames:
+        if frame.size != base:
+            mismatched = True
+            frame = frame.resize(base, resample=Image.NEAREST)
+        out.append(frame)
+    if mismatched:
+        print(
+            f"Warning: frames had differing sizes; normalised all to "
+            f"{base[0]}x{base[1]}.",
+            file=sys.stderr,
+        )
+    return out
+
+
+def _coalesce_animation(img: Image.Image):
+    """Flatten a possibly-delta-encoded GIF/APNG into full RGBA frames.
+
+    Composites each frame onto a running canvas so partial frames and disposal
+    semantics resolve to standalone images. Fully-opaque frames simply replace
+    the canvas (the common case), so independent frames are preserved exactly.
+    Returns ``(frames, durations_ms)``.
+    """
+    frames: list[Image.Image] = []
+    durations: list[int] = []
+    canvas = None
+    for raw in ImageSequence.Iterator(img):
+        frame = raw.convert("RGBA")
+        if canvas is None:
+            canvas = frame.copy()
+        else:
+            canvas = Image.alpha_composite(canvas, frame)
+        frames.append(canvas.copy())
+        durations.append(
+            int(raw.info.get("duration", img.info.get("duration", 100)) or 100)
+        )
+    return frames, durations
+
+
+def _load_video_frames(path: str):
+    cv2 = _import_cv2()
+    cap = cv2.VideoCapture(path)
+    if not cap.isOpened():
+        raise ValueError(f"Could not open video: {path}")
+    fps = cap.get(cv2.CAP_PROP_FPS) or 0.0
+    frames: list[Image.Image] = []
+    try:
+        while True:
+            ok, bgr = cap.read()
+            if not ok:
+                break
+            rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+            frames.append(Image.fromarray(rgb).convert("RGBA"))
+    finally:
+        cap.release()
+    if not frames:
+        raise ValueError(f"No frames decoded from video: {path}")
+    duration = int(round(1000.0 / fps)) if fps and fps > 0 else 100
+    meta = {
+        "durations": [duration] * len(frames),
+        "loop": 0,
+        "kind": "video",
+        "fps": fps if fps and fps > 0 else 10.0,
+    }
+    return _normalize_sizes(frames), meta
+
+
+def load_frames(source: str):
+    """Load animation frames from a file, URL, or directory.
+
+    Returns ``(frames, meta)`` where ``frames`` are equal-size, fully-coalesced
+    RGBA images and ``meta`` is ``{durations, loop, kind}`` (``kind`` is one of
+    ``single``/``gif``/``apng``/``frame_dir``/``video``).
+    """
+    meta = {"durations": None, "loop": 0, "kind": "single"}
+
+    # Directory of numbered frames.
+    if isinstance(source, str) and os.path.isdir(source):
+        paths = sorted(
+            (
+                p
+                for p in glob.glob(os.path.join(source, "*"))
+                if p.lower().endswith(_FRAME_DIR_EXTS)
+            ),
+            key=lambda p: _natural_key(os.path.basename(p)),
+        )
+        if not paths:
+            raise ValueError(f"No image frames found in directory: {source}")
+        frames = [Image.open(p).convert("RGBA") for p in paths]
+        meta["kind"] = "frame_dir"
+        return _normalize_sizes(frames), meta
+
+    # Video file.
+    if isinstance(source, str) and source.lower().endswith(VIDEO_EXTS):
+        return _load_video_frames(source)
+
+    # Single image, animated GIF/APNG, or URL (reuses still-image loader).
+    img = load_image(source)
+    if img is None:
+        raise ValueError(f"Could not load image from: {source}")
+
+    if getattr(img, "is_animated", False) and getattr(img, "n_frames", 1) > 1:
+        frames, durations = _coalesce_animation(img)
+        meta["kind"] = "gif" if (img.format == "GIF") else "apng"
+        meta["durations"] = durations
+        meta["loop"] = img.info.get("loop", 0)
+        return _normalize_sizes(frames), meta
+
+    return [img.convert("RGBA")], meta
+
+
+# --------------------------------------------------------------------------- #
+# Saving                                                                       #
+# --------------------------------------------------------------------------- #
+def _looks_like_dir_output(path: str) -> bool:
+    return os.path.isdir(path) or os.path.splitext(path)[1] == ""
+
+
+def _duration_list(durations, n: int):
+    if durations is None:
+        return None
+    if isinstance(durations, (int, float)):
+        return [int(durations)] * n
+    out = [int(x) for x in durations]
+    if not out:
+        return None
+    if len(out) < n:
+        out = out + [out[-1]] * (n - len(out))
+    return out[:n]
+
+
+def _shared_palette_quantize(frames: list[Image.Image]) -> list[Image.Image]:
+    """Quantize every frame against ONE shared adaptive palette.
+
+    ``create_downsampled_image``'s quantization is deterministic, so the only
+    place per-frame flicker can creep in is GIF's per-frame adaptive palette.
+    Building a single palette from all frames removes that flicker. Index 255 is
+    reserved for transparency (alpha == 0).
+    """
+    w, h = frames[0].size
+    montage = Image.new("RGB", (w, h * len(frames)))
+    for i, frame in enumerate(frames):
+        montage.paste(frame.convert("RGB"), (0, i * h))
+    # 255 colours so palette index 255 is free for a transparency slot.
+    palette_img = montage.convert("P", palette=Image.ADAPTIVE, colors=255)
+
+    out = []
+    for frame in frames:
+        p = frame.convert("RGB").quantize(palette=palette_img, dither=Image.Dither.NONE)
+        if frame.mode == "RGBA":
+            transparent = frame.getchannel("A").point(lambda a: 255 if a == 0 else 0)
+            transparent = transparent.convert("1")
+            if transparent.getbbox() is not None:
+                p.paste(255, transparent)
+                p.info["transparency"] = 255
+        out.append(p)
+    return out
+
+
+def _save_gif(frames, path, durations, loop):
+    rgba = [f.convert("RGBA") for f in frames]
+    pal_frames = _shared_palette_quantize(rgba)
+    dur = _duration_list(durations, len(frames)) or 100
+    save_kwargs = dict(
+        save_all=True,
+        append_images=pal_frames[1:],
+        duration=dur,
+        loop=loop or 0,
+        disposal=2,
+        optimize=False,
+    )
+    if "transparency" in pal_frames[0].info:
+        save_kwargs["transparency"] = 255
+    pal_frames[0].save(path, **save_kwargs)
+    print(f"Success: animation saved to '{path}' ({len(frames)} frames)")
+
+
+def _save_apng(frames, path, durations, loop):
+    rgba = [f.convert("RGBA") for f in frames]
+    dur = _duration_list(durations, len(frames)) or 100
+    rgba[0].save(
+        path,
+        save_all=True,
+        append_images=rgba[1:],
+        duration=dur,
+        loop=loop or 0,
+    )
+    print(f"Success: animation saved to '{path}' ({len(frames)} frames)")
+
+
+def _save_video(frames, path, durations):
+    cv2 = _import_cv2()
+    dur = _duration_list(durations, len(frames))
+    if dur:
+        avg_ms = sum(dur) / len(dur)
+        fps = 1000.0 / avg_ms if avg_ms > 0 else 10.0
+    else:
+        fps = 10.0
+
+    rgb_frames = [np.array(f.convert("RGB")) for f in frames]
+    h, w = rgb_frames[0].shape[:2]
+    # Many codecs reject odd dimensions; pad by one pixel where needed.
+    pad_w, pad_h = w + (w % 2), h + (h % 2)
+
+    ext = os.path.splitext(path)[1].lower()
+    fourcc_str = "VP80" if ext == ".webm" else "mp4v"
+    writer = cv2.VideoWriter(
+        path, cv2.VideoWriter_fourcc(*fourcc_str), fps, (pad_w, pad_h)
+    )
+    if not writer.isOpened():
+        raise RuntimeError(
+            f"Could not open a video writer for '{path}' (codec '{fourcc_str}'). "
+            "Try a .mp4 output, or upscale tiny frames with --res."
+        )
+    try:
+        for rgb in rgb_frames:
+            if (pad_w, pad_h) != (w, h):
+                padded = np.zeros((pad_h, pad_w, 3), dtype=np.uint8)
+                padded[:h, :w] = rgb
+                rgb = padded
+            writer.write(cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR))
+    finally:
+        writer.release()
+    print(f"Success: video saved to '{path}' ({len(frames)} frames @ {fps:.1f} fps)")
+
+
+def save_frames(frames, path, durations=None, loop: int = 0) -> None:
+    """Write *frames* out, dispatching on the output path.
+
+    ``.gif`` -> animated GIF (shared palette); ``.png``/``.apng`` -> APNG;
+    ``.mp4``/``.webm``/... -> video; an existing directory or an extension-less
+    path -> numbered ``frame_0000.png`` files.
+    """
+    if not frames:
+        raise ValueError("No frames to save.")
+
+    if _looks_like_dir_output(path):
+        os.makedirs(path, exist_ok=True)
+        pad = max(4, len(str(len(frames) - 1)))
+        for i, frame in enumerate(frames):
+            frame.convert("RGBA").save(
+                os.path.join(path, f"frame_{i:0{pad}d}.png")
+            )
+        print(f"Success: {len(frames)} frames saved to '{path}/'")
+        return
+
+    ext = os.path.splitext(path)[1].lower()
+    if ext in VIDEO_EXTS:
+        _save_video(frames, path, durations)
+    elif ext == ".gif":
+        _save_gif(frames, path, durations, loop)
+    elif ext in (".png", ".apng"):
+        _save_apng(frames, path, durations, loop)
+    else:
+        raise ValueError(
+            f"Unsupported animation output extension: '{ext}'. Use .gif, .png "
+            "(APNG), a video extension (.mp4/.webm), or a directory."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Processing                                                                   #
+# --------------------------------------------------------------------------- #
+def _shared_crop(frames: list[Image.Image]) -> list[Image.Image]:
+    """Crop every frame to the UNION of per-frame content boxes.
+
+    Cropping each frame independently would make the sprite size jitter as the
+    content moves; a single shared box keeps every output frame the same size.
+    """
+    if any(f.mode != "RGBA" for f in frames):
+        return frames  # mirrors the still-image crop guard (RGBA only)
+
+    union = None
+    for frame in frames:
+        alpha = np.array(frame.getchannel("A"))
+        ys, xs = np.where(alpha > 0)
+        if len(xs) == 0:
+            continue
+        bbox = [int(xs.min()), int(ys.min()), int(xs.max()) + 1, int(ys.max()) + 1]
+        if union is None:
+            union = bbox
+        else:
+            union[0] = min(union[0], bbox[0])
+            union[1] = min(union[1], bbox[1])
+            union[2] = max(union[2], bbox[2])
+            union[3] = max(union[3], bbox[3])
+
+    if union is None:
+        return frames  # every frame fully transparent
+    return [frame.crop(tuple(union)) for frame in frames]
+
+
+def process_frames(
+    frames,
+    *,
+    min_grid: int = 4,
+    quantize: int = 8,
+    offset=None,
+    auto_offset: bool = False,
+    crop: bool = False,
+    symmetric: bool = False,
+    res=None,
+    aspect_ratio=None,
+    verbose: bool = True,
+) -> list[Image.Image]:
+    """Downsample a list of frames against ONE shared grid.
+
+    Pure (no file I/O), so both the CLI animation path and the ComfyUI batch
+    node reuse it. Detects a single grid + phase offset across all frames, then
+    downsamples each frame to the identical cell count. Returns frames unchanged
+    if no grid is found or the animation is already clean (idempotence).
+    """
+    frames = _normalize_sizes(list(frames))
+    if not frames:
+        return []
+
+    grid_w, grid_h, det_ox, det_oy = detect_grid_across_frames(
+        frames, min_grid_size=min_grid
+    )
+    if grid_w <= 0 or grid_h <= 0:
+        if verbose:
+            print("No consistent grid detected across frames; returning unchanged.")
+        return list(frames)
+
+    if offset is not None:
+        off_x, off_y = offset
+    elif auto_offset:
+        off_x, off_y = det_ox, det_oy
+    else:
+        off_x, off_y = 0, 0
+
+    width, height = frames[0].size
+    num_cells_w = max(1, round(width / grid_w))
+    num_cells_h = max(1, round(height / grid_h))
+
+    if num_cells_w == width and num_cells_h == height:
+        if verbose:
+            print("Animation already appears to be clean pixel art; returning unchanged.")
+        return list(frames)
+
+    if verbose:
+        print(
+            f"Shared grid {grid_w}x{grid_h} px/cell -> {num_cells_w}x{num_cells_h} "
+            f"cells (offset {off_x},{off_y}) across {len(frames)} frame(s)."
+        )
+
+    out = [
+        create_downsampled_image(
+            frame,
+            grid_w,
+            grid_h,
+            num_cells_w,
+            num_cells_h,
+            quantize,
+            offset_x=off_x,
+            offset_y=off_y,
+        )
+        for frame in frames
+    ]
+
+    if symmetric:
+        out = [enforce_symmetry(frame) for frame in out]
+    if crop:
+        out = _shared_crop(out)
+    if res is not None:
+        out = [apply_resolution(frame, res) for frame in out]
+    elif aspect_ratio is not None:
+        out = [apply_aspect_ratio(frame, aspect_ratio) for frame in out]
+
+    return out
+
+
+def process_animation(
+    source: str,
+    output_file=None,
+    *,
+    min_grid: int = 4,
+    quantize: int = 8,
+    offset=None,
+    auto_offset: bool = False,
+    crop: bool = False,
+    symmetric: bool = False,
+    res=None,
+    aspect_ratio=None,
+    fps=None,
+    duration=None,
+    show: bool = False,
+) -> list[Image.Image]:
+    """Load an animation, downsample every frame against one shared grid, save it.
+
+    Output frame timing precedence: explicit ``duration`` (ms) > ``fps`` >
+    the source animation's original per-frame timing > 100 ms.
+    """
+    frames, meta = load_frames(source)
+    print(f"Loaded {len(frames)} frame(s) from '{source}' (kind={meta['kind']}).")
+
+    if len(frames) == 1:
+        print("Single frame detected; processing as a still image.")
+
+    out = process_frames(
+        frames,
+        min_grid=min_grid,
+        quantize=quantize,
+        offset=offset,
+        auto_offset=auto_offset,
+        crop=crop,
+        symmetric=symmetric,
+        res=res,
+        aspect_ratio=aspect_ratio,
+    )
+
+    if duration is not None:
+        durations = [int(duration)] * len(out)
+    elif fps is not None and fps > 0:
+        durations = [int(round(1000.0 / fps))] * len(out)
+    else:
+        durations = meta.get("durations")
+    loop = meta.get("loop", 0)
+
+    if output_file:
+        save_frames(out, output_file, durations=durations, loop=loop)
+    elif show:
+        out[0].show(title=f"{source} (frame 1/{len(out)})")
+        print(
+            "Note: --show displays the first frame only; use -o to save the full animation."
+        )
+    else:
+        print(
+            f"Processed {len(out)} frame(s). No -o/--output given, so nothing was written."
+        )
+
+    return out

--- a/src/spritegrid/cli.py
+++ b/src/spritegrid/cli.py
@@ -186,6 +186,27 @@ def parse_args() -> argparse.Namespace:
         ),
     )
 
+    timing = parser.add_mutually_exclusive_group()
+    timing.add_argument(
+        "--fps",
+        type=float,
+        default=None,
+        help=(
+            "Animation only: frames-per-second for the output (GIF/APNG/video). "
+            "Mutually exclusive with --duration. Defaults to the source's timing."
+        ),
+    )
+    timing.add_argument(
+        "--duration",
+        type=int,
+        default=None,
+        metavar="MS",
+        help=(
+            "Animation only: milliseconds per frame for the output. "
+            "Mutually exclusive with --fps. Defaults to the source's timing."
+        ),
+    )
+
     args = parser.parse_args()
 
     # Ensure the crop argument is passed correctly
@@ -200,8 +221,40 @@ def parse_args() -> argparse.Namespace:
 def cli() -> None:
     """
     The main entry point for the command line interface.
+
+    Multi-frame inputs (animated GIF/APNG, a directory of frames, or a video
+    file) are auto-routed to the animation pipeline, which detects ONE shared
+    grid across all frames. Everything else goes through the single-image path.
     """
     args = parse_args()
+
+    # Auto-route animations (lazy import keeps the still-image path cheap).
+    from .animation import is_animated_source
+
+    if is_animated_source(args.image_source):
+        from .animation import process_animation
+
+        try:
+            process_animation(
+                args.image_source,
+                output_file=args.output_file,
+                min_grid=args.min_grid,
+                quantize=args.quantize,
+                offset=args.offset,
+                auto_offset=args.auto_offset,
+                crop=args.crop,
+                symmetric=args.symmetric,
+                res=args.res,
+                aspect_ratio=args.aspectratio,
+                fps=args.fps,
+                duration=args.duration,
+                show=args.show,
+            )
+        except Exception as e:
+            print(f"Error processing animation: {e}", file=sys.stderr)
+            sys.exit(1)
+        return
+
     main(
         image_source=args.image_source,
         min_grid=args.min_grid,

--- a/src/spritegrid/comfyui/nodes.py
+++ b/src/spritegrid/comfyui/nodes.py
@@ -29,6 +29,30 @@ def pil_to_tensor(pil_img: Image.Image) -> torch.Tensor:
     return torch.from_numpy(img).unsqueeze(0)
 
 
+def tensor_batch_to_pils(tensor: torch.Tensor) -> list[Image.Image]:
+    """Convert a ComfyUI IMAGE batch tensor (B,H,W,C) to a list of PIL Images.
+
+    Accepts a single (H,W,C) tensor too (treated as a one-frame batch).
+    """
+    arr = tensor.cpu().numpy()
+    if arr.ndim == 3:
+        arr = arr[None, ...]
+    return [
+        Image.fromarray((frame * 255).clip(0, 255).astype(np.uint8))
+        for frame in arr
+    ]
+
+
+def pils_to_tensor_batch(frames: list[Image.Image]) -> torch.Tensor:
+    """Stack same-size PIL frames into a ComfyUI IMAGE batch tensor (B,H,W,C)."""
+    tensors = []
+    for frame in frames:
+        if frame.mode != "RGBA":
+            frame = frame.convert("RGBA")
+        tensors.append(torch.from_numpy(np.array(frame).astype(np.float32) / 255.0))
+    return torch.stack(tensors, dim=0)
+
+
 class SpriteGrid:
     """
     Detect pixel grid in AI-generated pixel art and downsample to clean sprites.
@@ -108,10 +132,66 @@ class SpriteGrid:
         return (pil_to_tensor(result),)
 
 
+class SpriteGridAnimation:
+    """
+    Detect ONE shared pixel grid across an image *batch* (animation) and
+    downsample every frame against it.
+
+    Single-frame workflows can use the plain SpriteGrid node; this node is for
+    batches (e.g. AnimateDiff / video frames) where per-frame detection would
+    make the resolution, grid phase, and palette jitter between frames. One
+    shared grid keeps the whole animation temporally stable.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "images": ("IMAGE",),
+            },
+            "optional": {
+                "min_grid": ("INT", {
+                    "default": 4,
+                    "min": 1,
+                    "max": 32,
+                    "step": 1,
+                }),
+                "quantize": ("INT", {
+                    "default": 8,
+                    "min": 4,
+                    "max": 8,
+                    "step": 1,
+                }),
+                "auto_offset": ("BOOLEAN", {"default": False}),
+                "crop": ("BOOLEAN", {"default": False}),
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "process"
+    CATEGORY = "image/sprite"
+
+    def process(self, images, min_grid=4, quantize=8, auto_offset=False, crop=False):
+        from ..animation import process_frames
+
+        frames = tensor_batch_to_pils(images)
+        out = process_frames(
+            frames,
+            min_grid=min_grid,
+            quantize=quantize,
+            auto_offset=auto_offset,
+            crop=crop,
+            verbose=False,
+        )
+        return (pils_to_tensor_batch(out),)
+
+
 NODE_CLASS_MAPPINGS = {
     "SpriteGrid": SpriteGrid,
+    "SpriteGridAnimation": SpriteGridAnimation,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "SpriteGrid": "SpriteGrid",
+    "SpriteGridAnimation": "SpriteGrid (Animation)",
 }

--- a/src/spritegrid/detection.py
+++ b/src/spritegrid/detection.py
@@ -2,7 +2,7 @@
 
 import sys
 import traceback
-from typing import Tuple
+from typing import Sequence, Tuple
 from collections import Counter
 
 import numpy as np
@@ -105,6 +105,118 @@ def find_grid_offset(profile: np.ndarray, spacing: int) -> int:
     return best_offset
 
 
+def compute_gradient_profiles(
+    image: Image.Image,
+    smoothing_sigma: float = 1.0,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Compute the 1D horizontal and vertical gradient profiles of an image.
+
+    profile_h has length = image width (drives grid_w / offset_x);
+    profile_v has length = image height (drives grid_h / offset_y).
+
+    This is the per-image signal that grid detection consumes; exposing it
+    separately lets callers aggregate profiles across multiple frames (see
+    detect_grid_across_frames) before peak detection.
+
+    Args:
+        image: The PIL Image object to analyze.
+        smoothing_sigma: Gaussian smoothing sigma (0 to disable).
+
+    Returns:
+        Tuple (profile_h, profile_v) of 1D NumPy arrays.
+    """
+    # Convert to grayscale
+    gray_image = (
+        image.split()[0] if image.mode in ("RGBA", "LA") else image.convert("L")
+    )
+    img_array = np.array(gray_image, dtype=np.float32)
+
+    # Calculate gradients
+    gradient_h = np.abs(np.diff(img_array, axis=1, append=img_array[:, -1:]))
+    gradient_v = np.abs(np.diff(img_array, axis=0, append=img_array[-1:, :]))
+
+    # Sum to create 1D profiles
+    profile_h = np.sum(gradient_h, axis=0)
+    profile_v = np.sum(gradient_v, axis=1)
+
+    # Optional smoothing
+    if smoothing_sigma and smoothing_sigma > 0:
+        profile_v = gaussian_filter1d(profile_v, sigma=smoothing_sigma)
+        profile_h = gaussian_filter1d(profile_h, sigma=smoothing_sigma)
+
+    return profile_h, profile_v
+
+
+def detect_grid_from_profiles(
+    profile_h: np.ndarray,
+    profile_v: np.ndarray,
+    min_grid_size: int = 4,
+    min_confidence: float = 0.4,
+) -> Tuple[int, int, int, int]:
+    """
+    Run grid detection on precomputed 1D gradient profiles.
+
+    profile_h drives grid_w / offset_x (its length is the image width);
+    profile_v drives grid_h / offset_y (its length is the image height).
+
+    Returns (grid_w, grid_h, offset_x, offset_y) or (0, 0, 0, 0) if no
+    reliable grid is detected (failure, low confidence, or implausible
+    aspect ratio).
+
+    Args:
+        profile_h: Horizontal gradient profile (length = image width).
+        profile_v: Vertical gradient profile (length = image height).
+        min_grid_size: Minimum expected grid dimension for peak finding.
+        min_confidence: Minimum confidence threshold (0-1) to accept detection.
+
+    Returns:
+        Tuple (grid_w, grid_h, offset_x, offset_y) or (0, 0, 0, 0).
+    """
+    actual_min_spacing = max(1, min_grid_size)
+
+    # Profiles too small for analysis
+    if (
+        len(profile_v) < actual_min_spacing * 2
+        or len(profile_h) < actual_min_spacing * 2
+    ):
+        return (0, 0, 0, 0)
+
+    # Find dominant spacing with confidence
+    grid_h, conf_h = find_dominant_spacing(profile_v, min_spacing=actual_min_spacing)
+    grid_w, conf_w = find_dominant_spacing(profile_h, min_spacing=actual_min_spacing)
+
+    # Check if detection failed
+    if grid_w <= 0 or grid_h <= 0:
+        return (0, 0, 0, 0)
+
+    # Check confidence threshold
+    avg_confidence = (conf_h + conf_w) / 2
+    if avg_confidence < min_confidence:
+        print(
+            f"Grid detection confidence too low ({avg_confidence:.2f} < {min_confidence}). "
+            "Image may already be clean pixel art.",
+            file=sys.stderr,
+        )
+        return (0, 0, 0, 0)
+
+    # Check grid aspect ratio - genuine pixel art grids are roughly square
+    grid_ratio = grid_w / grid_h
+    if grid_ratio < 0.5 or grid_ratio > 2.0:
+        print(
+            f"Detected grid {grid_w}x{grid_h} has inconsistent aspect ratio ({grid_ratio:.2f}). "
+            "Image may already be clean pixel art.",
+            file=sys.stderr,
+        )
+        return (0, 0, 0, 0)
+
+    # Detect grid phase offset using the already-computed gradient profiles
+    offset_x = find_grid_offset(profile_h, grid_w)
+    offset_y = find_grid_offset(profile_v, grid_h)
+
+    return grid_w, grid_h, offset_x, offset_y
+
+
 def detect_grid(
     image: Image.Image,
     min_grid_size: int = 4,
@@ -155,66 +267,10 @@ def detect_grid_with_offset(
         Tuple (grid_w, grid_h, offset_x, offset_y) or (0, 0, 0, 0).
     """
     try:
-        # Convert to grayscale
-        gray_image = (
-            image.split()[0] if image.mode in ("RGBA", "LA") else image.convert("L")
+        profile_h, profile_v = compute_gradient_profiles(image, smoothing_sigma)
+        return detect_grid_from_profiles(
+            profile_h, profile_v, min_grid_size, min_confidence
         )
-        img_array = np.array(gray_image, dtype=np.float32)
-        img_h, img_w = img_array.shape
-
-        actual_min_spacing = max(1, min_grid_size)
-
-        # Image too small for analysis
-        if img_h < actual_min_spacing * 2 or img_w < actual_min_spacing * 2:
-            return (0, 0, 0, 0)
-
-        # Calculate gradients
-        gradient_h = np.abs(np.diff(img_array, axis=1, append=img_array[:, -1:]))
-        gradient_v = np.abs(np.diff(img_array, axis=0, append=img_array[-1:, :]))
-
-        # Sum to create 1D profiles
-        profile_h = np.sum(gradient_h, axis=0)
-        profile_v = np.sum(gradient_v, axis=1)
-
-        # Optional smoothing
-        if smoothing_sigma and smoothing_sigma > 0:
-            profile_v = gaussian_filter1d(profile_v, sigma=smoothing_sigma)
-            profile_h = gaussian_filter1d(profile_h, sigma=smoothing_sigma)
-
-        # Find dominant spacing with confidence
-        grid_h, conf_h = find_dominant_spacing(profile_v, min_spacing=actual_min_spacing)
-        grid_w, conf_w = find_dominant_spacing(profile_h, min_spacing=actual_min_spacing)
-
-        # Check if detection failed
-        if grid_w <= 0 or grid_h <= 0:
-            return (0, 0, 0, 0)
-
-        # Check confidence threshold
-        avg_confidence = (conf_h + conf_w) / 2
-        if avg_confidence < min_confidence:
-            print(
-                f"Grid detection confidence too low ({avg_confidence:.2f} < {min_confidence}). "
-                "Image may already be clean pixel art.",
-                file=sys.stderr,
-            )
-            return (0, 0, 0, 0)
-
-        # Check grid aspect ratio - genuine pixel art grids are roughly square
-        grid_ratio = grid_w / grid_h
-        if grid_ratio < 0.5 or grid_ratio > 2.0:
-            print(
-                f"Detected grid {grid_w}x{grid_h} has inconsistent aspect ratio ({grid_ratio:.2f}). "
-                "Image may already be clean pixel art.",
-                file=sys.stderr,
-            )
-            return (0, 0, 0, 0)
-
-        # Detect grid phase offset using the already-computed gradient profiles
-        offset_x = find_grid_offset(profile_h, grid_w)
-        offset_y = find_grid_offset(profile_v, grid_h)
-
-        return grid_w, grid_h, offset_x, offset_y
-
     except ImportError:
         print(
             "Error: SciPy or NumPy not found. Install with: pip install numpy scipy pillow",
@@ -225,3 +281,62 @@ def detect_grid_with_offset(
         print(f"Grid detection error: {e}", file=sys.stderr)
         traceback.print_exc()
         return (0, 0, 0, 0)
+
+
+def detect_grid_across_frames(
+    frames: Sequence[Image.Image],
+    min_grid_size: int = 4,
+    smoothing_sigma: float = 1.0,
+    min_confidence: float = 0.4,
+) -> Tuple[int, int, int, int]:
+    """
+    Detect a single shared grid across multiple animation frames.
+
+    Sums the per-frame 1D gradient profiles *before* peak detection. Grid
+    lines fall at fixed pixel positions in every frame, so their peaks add
+    coherently, while moving content edges land at different positions and
+    average down. Detection therefore becomes *more* robust as the frame
+    count grows, and every frame is guaranteed the same grid -> the
+    downsampled animation is temporally stable (no resolution/phase jitter).
+
+    All frames must share the same dimensions (the animation orchestrator
+    normalises sizes before calling this).
+
+    Args:
+        frames: Sequence of PIL Image objects, all the same size.
+        min_grid_size: Minimum expected grid dimension for peak finding.
+        smoothing_sigma: Gaussian smoothing sigma (0 to disable).
+        min_confidence: Minimum confidence threshold (0-1) to accept detection.
+
+    Returns:
+        Tuple (grid_w, grid_h, offset_x, offset_y) or (0, 0, 0, 0).
+
+    Raises:
+        ValueError: if frames have differing dimensions.
+    """
+    frames = list(frames)
+    if not frames:
+        return (0, 0, 0, 0)
+    if len(frames) == 1:
+        return detect_grid_with_offset(
+            frames[0], min_grid_size, smoothing_sigma, min_confidence
+        )
+
+    sizes = {f.size for f in frames}
+    if len(sizes) > 1:
+        raise ValueError(
+            f"All frames must share the same dimensions for grid detection; got {sizes}"
+        )
+
+    sum_h = None
+    sum_v = None
+    for frame in frames:
+        profile_h, profile_v = compute_gradient_profiles(frame, smoothing_sigma)
+        if sum_h is None:
+            sum_h = profile_h.astype(np.float64)
+            sum_v = profile_v.astype(np.float64)
+        else:
+            sum_h += profile_h
+            sum_v += profile_v
+
+    return detect_grid_from_profiles(sum_h, sum_v, min_grid_size, min_confidence)

--- a/tests/test_animation_detection.py
+++ b/tests/test_animation_detection.py
@@ -1,0 +1,69 @@
+"""Cross-frame grid detection (detect_grid_across_frames).
+
+The grid lives at fixed pixel positions across frames while content moves, so
+summing per-frame gradient profiles reinforces the grid and washes out moving
+content. These tests use frames with a *fixed* grid and *moving* content.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from spritegrid.detection import detect_grid_across_frames, detect_grid_with_offset
+
+
+def _frame(cell: int = 8, cells: int = 10, seed: int = 0,
+           block_cells: int = 2) -> Image.Image:
+    """A fixed grid with a grid-aligned moving block.
+
+    Real pixel-art animation moves the sprite by whole pixels, i.e. whole cells
+    of the upscaled grid, so the moving content's edges land on grid lines. The
+    grid sits at fixed positions in every frame; only the block moves.
+    """
+    w = h = cell * cells
+    arr = np.full((h, w, 3), 128, dtype=np.uint8)
+    for x in range(0, w, cell):
+        arr[:, x, :] = 0   # fixed vertical grid lines
+    for y in range(0, h, cell):
+        arr[y, :, :] = 0   # fixed horizontal grid lines
+    b = block_cells * cell
+    bx = ((seed * cell) % (w - b)) // cell * cell
+    by = ((seed * 2 * cell) % (h - b)) // cell * cell
+    arr[by:by + b, bx:bx + b] = [200, 60, 60]
+    return Image.fromarray(arr)
+
+
+class TestDetectAcrossFrames:
+    def test_recovers_shared_grid(self):
+        frames = [_frame(8, 10, s) for s in range(8)]
+        gw, gh, _ox, _oy = detect_grid_across_frames(frames)
+        assert (gw, gh) == (8, 8)
+
+    def test_returns_four_tuple(self):
+        frames = [_frame(8, 10, s) for s in range(3)]
+        assert len(detect_grid_across_frames(frames)) == 4
+
+    def test_aggregation_across_many_frames(self):
+        # Larger moving block across many frames; the shared grid still wins.
+        frames = [_frame(8, 12, s, block_cells=3) for s in range(12)]
+        assert detect_grid_across_frames(frames)[:2] == (8, 8)
+
+    def test_empty_returns_zeros(self):
+        assert detect_grid_across_frames([]) == (0, 0, 0, 0)
+
+    def test_single_frame_matches_still(self):
+        f = _frame(8, 10, 0)
+        assert detect_grid_across_frames([f]) == detect_grid_with_offset(f)
+
+    def test_mismatched_sizes_raise(self):
+        with pytest.raises(ValueError):
+            detect_grid_across_frames([_frame(8, 10), _frame(8, 8)])
+
+    def test_offset_in_valid_range(self):
+        frames = [_frame(8, 10, s) for s in range(5)]
+        gw, gh, ox, oy = detect_grid_across_frames(frames)
+        if gw > 0:
+            assert 0 <= ox < gw
+            assert 0 <= oy < gh

--- a/tests/test_animation_io.py
+++ b/tests/test_animation_io.py
@@ -1,0 +1,107 @@
+"""load_frames / save_frames round-trips for GIF, APNG, frame dirs, and video."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from spritegrid.animation import is_animated_source, load_frames, save_frames
+
+
+def _frames(n: int = 5, size: int = 16) -> list[Image.Image]:
+    out = []
+    for s in range(n):
+        arr = np.zeros((size, size, 4), dtype=np.uint8)
+        arr[..., 3] = 255
+        arr[:, :, 0] = (s * 40) % 256  # distinct red per frame (ordering probe)
+        out.append(Image.fromarray(arr))
+    return out
+
+
+class TestGif:
+    def test_roundtrip(self, tmp_path):
+        p = str(tmp_path / "a.gif")
+        save_frames(_frames(5), p, durations=[100] * 5, loop=0)
+        frames, meta = load_frames(p)
+        assert len(frames) == 5
+        assert meta["kind"] == "gif"
+        assert len({f.size for f in frames}) == 1
+
+    def test_duration_preserved_within_rounding(self, tmp_path):
+        p = str(tmp_path / "a.gif")
+        save_frames(_frames(4), p, durations=120)
+        # GIF stores centiseconds, so allow +-10ms.
+        assert abs(Image.open(p).info.get("duration", 0) - 120) <= 10
+
+    def test_has_global_palette(self, tmp_path):
+        p = str(tmp_path / "a.gif")
+        save_frames(_frames(5), p)
+        assert Image.open(p).getpalette() is not None
+
+
+class TestApng:
+    def test_roundtrip(self, tmp_path):
+        p = str(tmp_path / "a.png")
+        save_frames(_frames(5), p, durations=120)
+        frames, meta = load_frames(p)
+        assert len(frames) == 5
+        assert meta["kind"] == "apng"
+
+
+class TestFrameDir:
+    def test_natural_sort_roundtrip(self, tmp_path):
+        d = tmp_path / "frames"
+        d.mkdir()
+        for i, f in enumerate(_frames(12)):
+            f.save(d / f"frame{i}.png")  # un-padded: lexical sort would misorder
+        frames, meta = load_frames(str(d))
+        assert len(frames) == 12
+        assert meta["kind"] == "frame_dir"
+        # frame10 must load at index 10 (natural sort), not index 2 (lexical).
+        assert int(np.array(frames[10])[0, 0, 0]) == (10 * 40) % 256
+
+    def test_directory_output(self, tmp_path):
+        out = tmp_path / "out"
+        save_frames(_frames(5), str(out))
+        files = sorted(os.listdir(out))
+        assert len(files) == 5
+        assert files[0] == "frame_0000.png"
+
+
+class TestVideo:
+    def test_mp4_roundtrip(self, tmp_path):
+        cv2 = pytest.importorskip("cv2")
+        p = str(tmp_path / "v.mp4")
+        probe = cv2.VideoWriter(p, cv2.VideoWriter_fourcc(*"mp4v"), 10.0, (16, 16))
+        ok = probe.isOpened()
+        probe.release()
+        if not ok:
+            pytest.skip("No usable mp4 writer in this OpenCV build")
+        save_frames(_frames(6, 16), p, durations=[100] * 6)
+        frames, meta = load_frames(p)
+        assert meta["kind"] == "video"
+        assert len(frames) >= 5  # codecs may drop/add a frame; tolerate
+        assert frames[0].size == (16, 16)
+
+
+class TestClassification:
+    def test_single_image_is_one_frame(self, tmp_path):
+        p = tmp_path / "s.png"
+        _frames(1)[0].save(p)
+        frames, meta = load_frames(str(p))
+        assert len(frames) == 1
+        assert meta["kind"] == "single"
+
+    def test_is_animated_source(self, tmp_path):
+        gif = str(tmp_path / "a.gif")
+        save_frames(_frames(4), gif)
+        assert is_animated_source(gif) is True
+
+        still = tmp_path / "s.png"
+        _frames(1)[0].save(still)
+        assert is_animated_source(str(still)) is False
+
+        assert is_animated_source(str(tmp_path)) is True  # a directory

--- a/tests/test_animation_process.py
+++ b/tests/test_animation_process.py
@@ -1,0 +1,102 @@
+"""process_frames / process_animation orchestration + temporal stability."""
+
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image
+
+from spritegrid.animation import (
+    _shared_crop,
+    load_frames,
+    process_animation,
+    process_frames,
+    save_frames,
+)
+
+
+def _grid_frame(cell: int = 8, cells: int = 10, seed: int = 0,
+                block_cells: int = 2) -> Image.Image:
+    """Fixed full-contrast grid with a grid-aligned moving block (RGBA)."""
+    w = h = cell * cells
+    arr = np.full((h, w, 3), 128, dtype=np.uint8)
+    for x in range(0, w, cell):
+        arr[:, x, :] = 0
+    for y in range(0, h, cell):
+        arr[y, :, :] = 0
+    b = block_cells * cell
+    bx = ((seed * cell) % (w - b)) // cell * cell
+    by = ((seed * 2 * cell) % (h - b)) // cell * cell
+    arr[by:by + b, bx:bx + b] = [200, 60, 60]
+    return Image.fromarray(arr).convert("RGBA")
+
+
+class TestProcessFrames:
+    def test_uniform_output_size(self):
+        frames = [_grid_frame(8, 10, s) for s in range(6)]
+        out = process_frames(frames, min_grid=4, verbose=False)
+        assert len(out) == 6
+        assert len({f.size for f in out}) == 1
+        assert out[0].size == (10, 10)
+
+    def test_no_grid_passthrough(self):
+        frames = [Image.new("RGBA", (40, 40), (100, 150, 200, 255)) for _ in range(4)]
+        out = process_frames(frames, min_grid=4, verbose=False)
+        assert [f.size for f in out] == [(40, 40)] * 4
+
+    def test_res_constant_across_frames(self):
+        frames = [_grid_frame(8, 10, s) for s in range(4)]
+        out = process_frames(frames, min_grid=4, res=(32, 32), verbose=False)
+        assert all(f.size == (32, 32) for f in out)
+
+    def test_empty(self):
+        assert process_frames([], verbose=False) == []
+
+
+class TestSharedCrop:
+    def test_union_box_gives_constant_size(self):
+        # Content moves frame to frame; the union box keeps every output the
+        # same size (per-frame cropping would make the sprite jitter).
+        frames = []
+        for s in range(5):
+            a = np.zeros((20, 20, 4), dtype=np.uint8)
+            a[s:s + 5, s:s + 5] = [255, 0, 0, 255]  # moving opaque block
+            frames.append(Image.fromarray(a))
+        out = _shared_crop(frames)
+        assert len({f.size for f in out}) == 1
+        assert out[0].size == (9, 9)  # union spans x/y 0..8 inclusive
+
+    def test_all_transparent_left_unchanged(self):
+        frames = [Image.new("RGBA", (12, 12), (0, 0, 0, 0)) for _ in range(3)]
+        out = _shared_crop(frames)
+        assert [f.size for f in out] == [(12, 12)] * 3
+
+
+class TestProcessAnimation:
+    def test_gif_end_to_end(self, tmp_path):
+        frames = [_grid_frame(8, 10, s) for s in range(6)]
+        src = str(tmp_path / "in.gif")
+        save_frames(frames, src, durations=[100] * 6)
+        out_path = str(tmp_path / "out.gif")
+
+        out = process_animation(src, out_path, min_grid=4, auto_offset=True)
+        assert len(out) == 6
+
+        reload, _meta = load_frames(out_path)
+        assert len(reload) == 6
+        assert len({f.size for f in reload}) == 1
+        assert reload[0].size == (10, 10)
+
+    def test_single_frame_degrades_to_still(self, tmp_path):
+        src = str(tmp_path / "s.png")
+        _grid_frame(8, 10, 0).save(src)
+        out = process_animation(src, str(tmp_path / "o.png"), min_grid=4)
+        assert len(out) == 1
+        assert out[0].size == (10, 10)
+
+    def test_fps_sets_output_duration(self, tmp_path):
+        frames = [_grid_frame(8, 10, s) for s in range(4)]
+        src = str(tmp_path / "in.gif")
+        save_frames(frames, src)
+        out_path = str(tmp_path / "out.gif")
+        process_animation(src, out_path, min_grid=4, fps=20)  # 20fps -> 50ms
+        assert abs(Image.open(out_path).info.get("duration", 0) - 50) <= 10

--- a/tests/test_cli_animate.py
+++ b/tests/test_cli_animate.py
@@ -1,0 +1,84 @@
+"""CLI auto-routing of animations through the `spritegrid` command.
+
+Markus chose auto-routing (no separate command): `spritegrid` detects a
+multi-frame input and runs the animation pipeline; stills are unaffected.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+from PIL import Image, ImageSequence
+
+from spritegrid import cli as cli_mod
+from spritegrid.animation import is_animated_source, save_frames
+
+
+def _grid_frames(n: int = 6, cell: int = 8, cells: int = 10) -> list[Image.Image]:
+    out = []
+    for s in range(n):
+        w = h = cell * cells
+        arr = np.full((h, w, 3), 128, dtype=np.uint8)
+        for x in range(0, w, cell):
+            arr[:, x, :] = 0
+        for y in range(0, h, cell):
+            arr[y, :, :] = 0
+        b = 2 * cell
+        bx = ((s * cell) % (w - b)) // cell * cell  # grid-aligned moving block
+        by = ((s * 2 * cell) % (h - b)) // cell * cell
+        arr[by:by + b, bx:bx + b] = [200, 60, 60]
+        out.append(Image.fromarray(arr))
+    return out
+
+
+def _run_cli(argv: list[str]) -> None:
+    old = sys.argv
+    sys.argv = ["spritegrid"] + argv
+    try:
+        cli_mod.cli()
+    finally:
+        sys.argv = old
+
+
+class TestAutoRoute:
+    def test_gif_routes_to_animation(self, tmp_path):
+        src = tmp_path / "in.gif"
+        save_frames(_grid_frames(6), str(src), durations=[100] * 6)
+        out = tmp_path / "out.gif"
+
+        _run_cli([str(src), "-o", str(out), "--auto-offset"])
+
+        assert out.exists()
+        frames = list(ImageSequence.Iterator(Image.open(out)))
+        assert len(frames) == 6
+        assert len({f.size for f in frames}) == 1
+
+    def test_still_png_uses_single_image_path(self, tmp_path):
+        src = tmp_path / "s.png"
+        _grid_frames(1)[0].save(src)
+        out = tmp_path / "out.png"
+
+        _run_cli([str(src), "-o", str(out)])
+
+        assert out.exists()
+        assert Image.open(out).size == (10, 10)  # single downsampled sprite
+
+
+class TestTimingFlags:
+    def test_fps_and_duration_are_mutually_exclusive(self, tmp_path):
+        src = tmp_path / "in.gif"
+        save_frames(_grid_frames(4), str(src))
+        with pytest.raises(SystemExit):
+            _run_cli([str(src), "-o", str(tmp_path / "o.gif"),
+                      "--fps", "10", "--duration", "100"])
+
+
+class TestClassifier:
+    def test_directory_is_animated(self, tmp_path):
+        d = tmp_path / "frames"
+        d.mkdir()
+        for i, f in enumerate(_grid_frames(3)):
+            f.save(d / f"frame{i}.png")
+        assert is_animated_source(str(d)) is True

--- a/tests/test_comfyui_animation.py
+++ b/tests/test_comfyui_animation.py
@@ -1,0 +1,73 @@
+"""Tests for the SpriteGridAnimation ComfyUI batch node.
+
+Skipped automatically when torch isn't installed (ComfyUI provides it), exactly
+like test_comfyui_nodes.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+torch = pytest.importorskip("torch")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from spritegrid.comfyui.nodes import (  # noqa: E402
+    NODE_CLASS_MAPPINGS,
+    NODE_DISPLAY_NAME_MAPPINGS,
+    SpriteGridAnimation,
+    pils_to_tensor_batch,
+    tensor_batch_to_pils,
+)
+
+
+def _batch(n: int = 6, cell: int = 8, cells: int = 10) -> "torch.Tensor":
+    frames = []
+    for s in range(n):
+        w = h = cell * cells
+        arr = np.full((h, w, 3), 200, dtype=np.float32)
+        arr[::cell, :, :] = 40
+        arr[:, ::cell, :] = 40
+        rng = np.random.RandomState(s)
+        x = rng.randint(0, w - 18)
+        y = rng.randint(0, h - 18)
+        arr[y:y + 17, x:x + 17] = [220, 30, 30]
+        frames.append(arr / 255.0)
+    return torch.from_numpy(np.stack(frames))  # (n, h, w, 3)
+
+
+class TestTensorBatchHelpers:
+    def test_batch_to_pils_count_and_size(self):
+        pils = tensor_batch_to_pils(_batch(5))
+        assert len(pils) == 5
+        assert pils[0].size == (80, 80)
+
+    def test_single_image_tensor_treated_as_one_frame(self):
+        assert len(tensor_batch_to_pils(torch.zeros(8, 8, 3))) == 1
+
+    def test_pils_to_batch_shape(self):
+        pils = [Image.new("RGBA", (10, 10)) for _ in range(4)]
+        t = pils_to_tensor_batch(pils)
+        assert tuple(t.shape) == (4, 10, 10, 4)
+
+
+class TestSpriteGridAnimationNode:
+    def test_batch_downsampled_and_stable(self):
+        (out,) = SpriteGridAnimation().process(_batch(6), min_grid=4, auto_offset=True)
+        assert out.shape[0] == 6
+        assert tuple(out.shape[1:3]) == (10, 10)
+
+    def test_registered(self):
+        assert NODE_CLASS_MAPPINGS["SpriteGridAnimation"] is SpriteGridAnimation
+        assert "SpriteGridAnimation" in NODE_DISPLAY_NAME_MAPPINGS
+
+    def test_metadata(self):
+        types = SpriteGridAnimation.INPUT_TYPES()
+        assert "images" in types["required"]
+        assert SpriteGridAnimation.RETURN_TYPES == ("IMAGE",)
+        assert "image" in SpriteGridAnimation.CATEGORY.lower()

--- a/tests/test_detection_refactor.py
+++ b/tests/test_detection_refactor.py
@@ -1,0 +1,78 @@
+"""Regression + decomposition tests for the detection refactor.
+
+The grid-detection internals were split into compute_gradient_profiles() +
+detect_grid_from_profiles() so profiles can be aggregated across animation
+frames. These tests lock the existing single-image behaviour and verify the
+decomposition is exact.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image
+
+from spritegrid.detection import (
+    compute_gradient_profiles,
+    detect_grid,
+    detect_grid_from_profiles,
+    detect_grid_with_offset,
+)
+
+
+def _make_grid_image(cell_size: int, cells_w: int, cells_h: int,
+                     offset_x: int = 0, offset_y: int = 0) -> Image.Image:
+    w = cells_w * cell_size + offset_x
+    h = cells_h * cell_size + offset_y
+    arr = np.full((h, w, 3), 128, dtype=np.uint8)
+    for x in range(offset_x, w, cell_size):
+        arr[:, x, :] = 0
+    for y in range(offset_y, h, cell_size):
+        arr[y, :, :] = 0
+    return Image.fromarray(arr)
+
+
+class TestComputeGradientProfiles:
+    def test_profile_lengths_match_dimensions(self):
+        img = _make_grid_image(8, 10, 6)  # 80 x 48
+        profile_h, profile_v = compute_gradient_profiles(img)
+        assert len(profile_h) == img.width
+        assert len(profile_v) == img.height
+
+    def test_handles_rgba_and_l_modes(self):
+        rgba = _make_grid_image(8, 6, 6).convert("RGBA")
+        gray = _make_grid_image(8, 6, 6).convert("L")
+        for img in (rgba, gray):
+            ph, pv = compute_gradient_profiles(img)
+            assert len(ph) == img.width and len(pv) == img.height
+
+
+class TestDecompositionIsExact:
+    def test_from_profiles_equals_with_offset(self):
+        for cell in (4, 6, 8, 10):
+            img = _make_grid_image(cell, 9, 9)
+            ph, pv = compute_gradient_profiles(img)
+            assert detect_grid_from_profiles(ph, pv) == detect_grid_with_offset(img)
+
+    def test_too_small_profiles_return_zeros(self):
+        assert detect_grid_from_profiles(np.zeros(5), np.zeros(5), min_grid_size=4) == (
+            0, 0, 0, 0
+        )
+
+
+class TestBackwardCompatibility:
+    def test_known_grid_recovered(self):
+        img = _make_grid_image(8, 10, 10)
+        assert detect_grid_with_offset(img)[:2] == (8, 8)
+
+    def test_detect_grid_wrapper_matches(self):
+        img = _make_grid_image(8, 10, 10)
+        gw, gh, _ox, _oy = detect_grid_with_offset(img)
+        assert detect_grid(img) == (gw, gh)
+
+    def test_uniform_image_returns_zeros(self):
+        img = Image.fromarray(np.full((64, 64, 3), 128, dtype=np.uint8))
+        assert detect_grid_with_offset(img) == (0, 0, 0, 0)
+
+    def test_tiny_image_returns_zeros(self):
+        img = Image.fromarray(np.full((5, 5, 3), 128, dtype=np.uint8))
+        assert detect_grid_with_offset(img, min_grid_size=4) == (0, 0, 0, 0)


### PR DESCRIPTION
## What

Adds **animation support**: SpriteGrid now cleans animated GIF/APNG, folders of numbered frames, and video (`.mp4`/`.webm`), not just single images.

The core idea — treat the grid as a property of the **whole animation, not the frame**. It detects **one shared pixel grid across all frames** (by summing the per-frame gradient profiles) and downsamples every frame against that identical lattice. Because grid lines sit at fixed positions while content moves, aggregating *reinforces* the grid and *averages out* the motion — so detection is robust and the output is temporally stable: constant resolution, constant grid phase, and a shared palette (no flicker).

## Changes

- **`detection.py`** — extracted `compute_gradient_profiles()` + `detect_grid_from_profiles()` (with `detect_grid_with_offset` rewritten as a thin delegator, **100% backward-compatible** — locked by golden-value tests), and added `detect_grid_across_frames()`.
- **`animation.py`** (new) — `load_frames` / `save_frames` for GIF/APNG, numbered frame folders, and video (opencv, lazy-imported only on the video path → **no new dependency**); the pure `process_frames()` core and the `process_animation()` file-I/O wrapper. Handles GIF coalescing, duration/loop preservation, a **shared crop bbox** (so sprite size doesn't jitter), and a **shared GIF palette** (the real flicker source).
- **`cli.py`** — the existing `spritegrid` command **auto-routes** multi-frame inputs to the animation pipeline (no new command); adds `--fps` / `--duration`. Also adds `__main__.py` so `python -m spritegrid` works.
- **`comfyui/nodes.py`** — new **SpriteGrid (Animation)** batch node: one shared grid across an `IMAGE` batch (AnimateDiff / video frames), where the existing node only handled a batch of one.
- **`README.md`** — Animations section + ComfyUI animation node + new flags.

## Decisions

Scope was confirmed up front via four swipe-card decisions: include video (mp4/webm), auto-route inside `spritegrid` (no new command), include the ComfyUI batch node now, GIF/APNG + frame folders as the base.

## Tests

226 passed, 2 skipped (ComfyUI tests skip without torch, same as the existing suite). New coverage: detection-refactor regression, cross-frame detection, frame-I/O round-trips (GIF/APNG/frame-dir/video), orchestration + temporal stability, CLI auto-route, and the ComfyUI batch node. End-to-end verified: gif→gif, gif→frame-folder, gif→mp4.

Part of #47