### PR TITLE
feat: ANSI half-block output (-H/--halfblock)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ spritegrid ai_pixelart.png -o sprite.png --symmetric
 | `-c` | Crop to content after processing |
 | `-d` | Show debug grid overlay |
 | `-i` | Display output image |
-| `-a, --ascii SCALE` | Output as ANSI art |
+| `-a, --ascii SCALE` | Output as ANSI art (one colored space per pixel; SCALE widens each) |
+| `-H, --halfblock` | Output as ANSI half-block pixel art (`▀`, two pixels per cell — crisper) |
 | `--min-grid N` | Minimum grid size (default: 4) |
 | `-q, --quantize N` | Color bits: 4-8 (default: 8) |
 | `-s, --symmetric` | Enforce horizontal symmetry (higher-confidence pixel of each mirror pair wins) |

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ spritegrid ai_pixelart.png -o sprite.png --symmetric
 | `-c` | Crop to content after processing |
 | `-d` | Show debug grid overlay |
 | `-i` | Display output image |
-| `-a, --ascii SCALE` | Output as ANSI art (one colored space per pixel; SCALE widens each) |
-| `-H, --halfblock` | Output as ANSI half-block pixel art (`▀`, two pixels per cell — crisper) |
+| `-a, --ascii SCALE` | Still images: output as ANSI art (one colored space per pixel; SCALE widens each) |
+| `-H, --halfblock` | Still images: output as ANSI half-block pixel art (`▀`, two pixels per cell — crisper) |
 | `--min-grid N` | Minimum grid size (default: 4) |
 | `-q, --quantize N` | Color bits: 4-8 (default: 8) |
 | `-s, --symmetric` | Enforce horizontal symmetry (higher-confidence pixel of each mirror pair wins) |

--- a/src/spritegrid/cli.py
+++ b/src/spritegrid/cli.py
@@ -128,6 +128,14 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "-H",
+        "--halfblock",
+        action="store_true",
+        help="Print the result to stdout as truecolor ANSI half-block pixel art "
+        "(U+2580 '▀', two pixels per cell). With -o FILE.txt, saves the ANSI instead.",
+    )
+
+    parser.add_argument(
         "-s",
         "--symmetric",
         action="store_true",
@@ -265,6 +273,7 @@ def cli() -> None:
         remove_background=args.remove_background,
         crop=args.crop,
         ascii_space_width=args.ascii,
+        halfblock=args.halfblock,
         symmetric=args.symmetric,
         res=args.res,
         aspect_ratio=args.aspectratio,

--- a/src/spritegrid/cli.py
+++ b/src/spritegrid/cli.py
@@ -118,7 +118,8 @@ def parse_args() -> argparse.Namespace:
         help="Automatically crop the image to the first and last rows and columns where all pixels aren't transparent.",
     )
 
-    parser.add_argument(
+    ansi_output = parser.add_mutually_exclusive_group()
+    ansi_output.add_argument(
         "-a",
         "--ascii",
         nargs="?",
@@ -127,7 +128,7 @@ def parse_args() -> argparse.Namespace:
         type=int,
     )
 
-    parser.add_argument(
+    ansi_output.add_argument(
         "-H",
         "--halfblock",
         action="store_true",
@@ -240,6 +241,13 @@ def cli() -> None:
     from .animation import is_animated_source
 
     if is_animated_source(args.image_source):
+        if args.ascii is not None or args.halfblock:
+            print(
+                "Error: --ascii and --halfblock are only supported for still images.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
         from .animation import process_animation
 
         try:

--- a/src/spritegrid/main.py
+++ b/src/spritegrid/main.py
@@ -10,6 +10,7 @@ from spritegrid.segmentation import make_background_transparent
 from .detection import detect_grid_with_offset
 from .utils import (
     convert_image_to_ascii,
+    convert_image_to_halfblock,
     geometric_median,
     naive_median,
     crop_to_content,
@@ -356,13 +357,20 @@ def handle_output(
     is_debug: bool,
     default_title: str = "Spritegrid Output",
     ascii_space_width: Optional[int] = None,
+    halfblock: bool = False,
 ):
     """Helper function to save or show the processed image."""
     if save_path is not None:
-        if save_path.endswith(".txt") and ascii_space_width is None:
+        if save_path.endswith(".txt") and ascii_space_width is None and not halfblock:
             ascii_space_width = 1
 
-    show_stdout = (ascii_space_width is not None and save_path is None)
+    def _ansi(img: Image.Image) -> str:
+        if halfblock:
+            return convert_image_to_halfblock(img)
+        return convert_image_to_ascii(img, ascii_space_width)
+
+    ansi_requested = halfblock or ascii_space_width is not None
+    show_stdout = (ansi_requested and save_path is None)
     show_image = (show_flag or (save_path is None and not show_stdout))
 
     # Default action for debug mode if no other option is chosen
@@ -375,16 +383,15 @@ def handle_output(
         if save_path.endswith(".png"):
             handle_png(image, save_path)
         elif save_path.endswith(".txt"):
-            image_string = convert_image_to_ascii(image, ascii_space_width)
-            handle_txt(image_string, save_path)
+            handle_txt(_ansi(image), save_path)
     else:
         if show_image:
             type_str = "Debug Overlay" if is_debug else "Downsampled Image"
             title = f"{default_title} - {type_str}"
             handle_show_image(image, title)
-        
+
         if show_stdout:
-            print(convert_image_to_ascii(image, ascii_space_width))
+            print(_ansi(image))
 
 
 def handle_show_image(image: Image.Image, title: str) -> None:
@@ -474,6 +481,7 @@ def main(
     remove_background: Optional[str] = None,
     crop: bool = False,
     ascii_space_width: Optional[int] = None,
+    halfblock: bool = False,
     symmetric: bool = False,
     res: Optional[Tuple[int, int]] = None,
     aspect_ratio: Optional[Tuple[int, int]] = None,
@@ -610,6 +618,7 @@ def main(
                 is_debug=False,
                 default_title=f"{image_source} — Before / After",
                 ascii_space_width=ascii_space_width,
+                halfblock=halfblock,
             )
         elif debug:
             handle_output(
@@ -619,6 +628,7 @@ def main(
                 is_debug=True,
                 default_title=f"{image_source} ({num_cells_w}x{num_cells_h})",
                 ascii_space_width=ascii_space_width,
+                halfblock=halfblock,
             )
         else:
             handle_output(
@@ -628,6 +638,7 @@ def main(
                 is_debug=False,
                 default_title=f"{image_source} ({num_cells_w}x{num_cells_h})",
                 ascii_space_width=ascii_space_width,
+                halfblock=halfblock,
             )
 
     else:
@@ -641,4 +652,5 @@ def main(
             is_debug=False,
             default_title=f"{image_source} (unchanged)",
             ascii_space_width=ascii_space_width,
+            halfblock=halfblock,
         )

--- a/src/spritegrid/main.py
+++ b/src/spritegrid/main.py
@@ -360,6 +360,9 @@ def handle_output(
     halfblock: bool = False,
 ):
     """Helper function to save or show the processed image."""
+    if halfblock and ascii_space_width is not None:
+        raise ValueError("ascii_space_width and halfblock are mutually exclusive")
+
     if save_path is not None:
         if save_path.endswith(".txt") and ascii_space_width is None and not halfblock:
             ascii_space_width = 1
@@ -391,7 +394,7 @@ def handle_output(
             handle_show_image(image, title)
 
         if show_stdout:
-            print(_ansi(image))
+            print(_ansi(image), end="")
 
 
 def handle_show_image(image: Image.Image, title: str) -> None:

--- a/src/spritegrid/utils.py
+++ b/src/spritegrid/utils.py
@@ -26,6 +26,45 @@ def convert_image_to_ascii(
     return "".join(strings)
 
 
+def convert_image_to_halfblock(image: Image.Image) -> str:
+    """Render an image to truecolor ANSI using upper-half-block glyphs (U+2580 '▀').
+
+    Each character cell stacks TWO vertical pixels: the glyph's foreground colour is
+    the top pixel and its background colour is the bottom pixel. This doubles vertical
+    resolution over the one-space-per-pixel :func:`convert_image_to_ascii` and, because a
+    typical terminal cell is about twice as tall as it is wide, renders pixels roughly
+    square. Runs of identical cells reuse the previous colours to keep the string short.
+
+    Fully transparent pixels (alpha 0) are emitted as a default-coloured space so the
+    terminal background shows through.
+    """
+    image = image.convert("RGBA")
+    width, height = image.size
+    px = image.load()
+    if height % 2:  # need whole top/bottom pairs
+        height -= 1
+    strings = []
+    for y in range(0, height, 2):
+        last = None
+        for x in range(width):
+            tr, tg, tb, ta = px[x, y]
+            br, bg, bb, ba = px[x, y + 1]
+            if ta == 0 and ba == 0:
+                strings.append("\x1b[0m ")
+                last = None
+                continue
+            cur = (tr, tg, tb, br, bg, bb)
+            if cur == last:
+                strings.append("▀")
+            else:
+                strings.append(
+                    f"\x1b[38;2;{tr};{tg};{tb};48;2;{br};{bg};{bb}m▀"
+                )
+                last = cur
+        strings.append("\x1b[0m\n")
+    return "".join(strings)
+
+
 def naive_median(X: np.ndarray) -> np.ndarray:
     """
     Returns the naive median of points in X.

--- a/src/spritegrid/utils.py
+++ b/src/spritegrid/utils.py
@@ -35,30 +35,44 @@ def convert_image_to_halfblock(image: Image.Image) -> str:
     typical terminal cell is about twice as tall as it is wide, renders pixels roughly
     square. Runs of identical cells reuse the previous colours to keep the string short.
 
-    Fully transparent pixels (alpha 0) are emitted as a default-coloured space so the
-    terminal background shows through.
+    Transparent pixels (alpha 0) use the terminal's default background. If only one pixel
+    in a pair is visible, an upper or lower half-block renders that pixel without painting
+    the transparent half. An odd final row is paired with a transparent bottom row.
     """
     image = image.convert("RGBA")
     width, height = image.size
     px = image.load()
-    if height % 2:  # need whole top/bottom pairs
-        height -= 1
     strings = []
     for y in range(0, height, 2):
         last = None
         for x in range(width):
             tr, tg, tb, ta = px[x, y]
-            br, bg, bb, ba = px[x, y + 1]
-            if ta == 0 and ba == 0:
-                strings.append("\x1b[0m ")
-                last = None
-                continue
-            cur = (tr, tg, tb, br, bg, bb)
+            if y + 1 < height:
+                br, bg, bb, ba = px[x, y + 1]
+            else:
+                br, bg, bb, ba = 0, 0, 0, 0
+
+            top_visible = ta != 0
+            bottom_visible = ba != 0
+            if top_visible and bottom_visible:
+                cur = ("▀", tr, tg, tb, br, bg, bb)
+                escape = f"\x1b[38;2;{tr};{tg};{tb};48;2;{br};{bg};{bb}m"
+            elif top_visible:
+                cur = ("▀", tr, tg, tb)
+                escape = f"\x1b[0;38;2;{tr};{tg};{tb}m"
+            elif bottom_visible:
+                cur = ("▄", br, bg, bb)
+                escape = f"\x1b[0;38;2;{br};{bg};{bb}m"
+            else:
+                cur = (" ",)
+                escape = "\x1b[0m"
+
+            glyph = cur[0]
             if cur == last:
-                strings.append("▀")
+                strings.append(glyph)
             else:
                 strings.append(
-                    f"\x1b[38;2;{tr};{tg};{tb};48;2;{br};{bg};{bb}m▀"
+                    f"{escape}{glyph}"
                 )
                 last = cur
         strings.append("\x1b[0m\n")

--- a/tests/test_cli_animate.py
+++ b/tests/test_cli_animate.py
@@ -75,6 +75,24 @@ class TestTimingFlags:
                       "--fps", "10", "--duration", "100"])
 
 
+class TestAnsiFlags:
+    def test_ascii_and_halfblock_are_mutually_exclusive(self):
+        with pytest.raises(SystemExit) as exc:
+            _run_cli(["still.png", "--ascii", "--halfblock"])
+        assert exc.value.code == 2
+
+    @pytest.mark.parametrize("flag", ["--ascii", "--halfblock"])
+    def test_ansi_output_is_rejected_for_animations(self, tmp_path, flag, capsys):
+        src = tmp_path / "in.gif"
+        save_frames(_grid_frames(2), str(src))
+
+        with pytest.raises(SystemExit) as exc:
+            _run_cli([str(src), flag])
+
+        assert exc.value.code == 2
+        assert "only supported for still images" in capsys.readouterr().err
+
+
 class TestClassifier:
     def test_directory_is_animated(self, tmp_path):
         d = tmp_path / "frames"

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -1,7 +1,6 @@
 """Tests for spritegrid.main utility functions: load_image, handle_txt, handle_png, create_downsampled_image."""
 
 import os
-import sys
 from io import BytesIO
 from unittest.mock import patch, MagicMock
 
@@ -114,6 +113,33 @@ class TestHandlePng:
         handle_png(img, "/nonexistent/dir/out.png")
         err = capsys.readouterr().err
         assert "Error" in err
+
+
+# ---------------------------------------------------------------------------
+# handle_output ANSI modes
+# ---------------------------------------------------------------------------
+
+class TestHandleOutputAnsi:
+    def test_halfblock_stdout_has_no_extra_blank_row(self, capsys):
+        from spritegrid.main import handle_output
+
+        image = Image.new("RGB", (1, 2), (10, 20, 30))
+        handle_output(image, None, False, False, halfblock=True)
+        assert capsys.readouterr().out.count("\n") == 1
+
+    def test_ansi_modes_are_mutually_exclusive_for_direct_callers(self):
+        from spritegrid.main import handle_output
+
+        image = Image.new("RGB", (1, 2), (10, 20, 30))
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            handle_output(
+                image,
+                None,
+                False,
+                False,
+                ascii_space_width=1,
+                halfblock=True,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 from spritegrid.utils import (
     convert_image_to_ascii,
+    convert_image_to_halfblock,
     crop_to_content,
     geometric_median,
     naive_median,
@@ -139,6 +140,48 @@ class TestConvertImageToAscii:
     def test_returns_string(self):
         img = _rgba(2, 2)
         assert isinstance(convert_image_to_ascii(img), str)
+
+
+# ---------------------------------------------------------------------------
+# convert_image_to_halfblock
+# ---------------------------------------------------------------------------
+
+def _rgba_rows(colors):
+    """Build a 1-px-wide image, one row per color in *colors* (RGBA tuples)."""
+    arr = np.array([[c] for c in colors], dtype=np.uint8)
+    return Image.fromarray(arr)
+
+
+class TestConvertImageToHalfblock:
+    def test_returns_string(self):
+        assert isinstance(convert_image_to_halfblock(_rgba(2, 2)), str)
+
+    def test_opaque_cell_has_both_fg_and_bg(self):
+        result = convert_image_to_halfblock(_rgba(1, 2, (255, 0, 0, 255)))
+        assert "\x1b[38;2;" in result  # foreground (top pixel)
+        assert "48;2;" in result       # background (bottom pixel)
+        assert "▀" in result
+
+    def test_top_is_fg_bottom_is_bg(self):
+        # top row red, bottom row blue -> fg red, bg blue
+        img = _rgba_rows([(255, 0, 0, 255), (0, 0, 255, 255)])
+        result = convert_image_to_halfblock(img)
+        assert "38;2;255;0;0" in result
+        assert "48;2;0;0;255" in result
+
+    def test_one_cell_row_per_two_pixel_rows(self):
+        # 4 px tall -> 2 half-block rows -> 2 newlines
+        assert convert_image_to_halfblock(_rgba(2, 4)).count("\n") == 2
+
+    def test_odd_height_drops_last_row(self):
+        # 3 px tall -> only 1 complete pair -> 1 row
+        assert convert_image_to_halfblock(_rgba(2, 3)).count("\n") == 1
+
+    def test_transparent_pair_is_uncolored_space(self):
+        img = _transparent(1, 2)
+        result = convert_image_to_halfblock(img)
+        assert "38;2;" not in result and "48;2;" not in result
+        assert " " in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -173,15 +173,36 @@ class TestConvertImageToHalfblock:
         # 4 px tall -> 2 half-block rows -> 2 newlines
         assert convert_image_to_halfblock(_rgba(2, 4)).count("\n") == 2
 
-    def test_odd_height_drops_last_row(self):
-        # 3 px tall -> only 1 complete pair -> 1 row
-        assert convert_image_to_halfblock(_rgba(2, 3)).count("\n") == 1
+    def test_odd_height_preserves_last_row(self):
+        # 3 px tall -> one complete pair plus one top-only row.
+        result = convert_image_to_halfblock(_rgba(2, 3, (10, 20, 30, 255)))
+        assert result.count("\n") == 2
+        assert "0;38;2;10;20;30m▀" in result
+
+    def test_single_row_is_not_dropped(self):
+        result = convert_image_to_halfblock(_rgba(1, 1, (10, 20, 30, 255)))
+        assert result.count("\n") == 1
+        assert "0;38;2;10;20;30m▀" in result
 
     def test_transparent_pair_is_uncolored_space(self):
         img = _transparent(1, 2)
         result = convert_image_to_halfblock(img)
         assert "38;2;" not in result and "48;2;" not in result
         assert " " in result
+
+    def test_transparent_bottom_uses_default_background(self):
+        img = _rgba_rows([(10, 20, 30, 255), (200, 210, 220, 0)])
+        result = convert_image_to_halfblock(img)
+        assert "0;38;2;10;20;30m▀" in result
+        assert "48;2;" not in result
+        assert "200;210;220" not in result
+
+    def test_transparent_top_uses_lower_halfblock_and_default_background(self):
+        img = _rgba_rows([(200, 210, 220, 0), (10, 20, 30, 255)])
+        result = convert_image_to_halfblock(img)
+        assert "0;38;2;10;20;30m▄" in result
+        assert "48;2;" not in result
+        assert "200;210;220" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds truecolor **ANSI half-block** rendering alongside the existing `--ascii` output.

`convert_image_to_halfblock()` renders each character cell with upper/lower half-block glyphs. For opaque pairs, foreground is the top pixel and background is the bottom pixel. That packs two vertical pixels per terminal cell, doubling vertical resolution over `--ascii` and producing roughly square pixels.

## Usage

```bash
spritegrid sprite.png -H            # print half-block pixel art to stdout
spritegrid sprite.png -H -o art.txt # save the ANSI to a text file
```

## Changes

- Add `convert_image_to_halfblock()` with run-length color reuse.
- Preserve odd final rows instead of dropping them.
- Use the terminal default background for transparent halves; lower-half blocks handle transparent-top pairs.
- Add mutually exclusive `-a/--ascii` and `-H/--halfblock` CLI modes.
- Reject unsupported ANSI rendering for animated inputs instead of silently ignoring it.
- Avoid an extra blank row when writing ANSI to stdout.
- Document the still-image-only ANSI modes.

## Review checklist

- [x] Preserve odd final rows and 1-pixel-high images.
- [x] Correct top-only and bottom-only transparency.
- [x] Reject conflicting ANSI modes.
- [x] Reject ANSI flags for animated inputs.
- [x] Preserve exact stdout row count.

## Verification

- Full suite: **273 passed, 2 skipped**.
- Changed files pass Ruff.
- Focused ANSI/CLI suite: **58 passed**.

🤖 Generated with Claude Code and reviewed/fixed with Codex.
