### PR TITLE
perf: vectorize create_downsampled_image naive path (~40x)

### DIFF
--- a/src/spritegrid/main.py
+++ b/src/spritegrid/main.py
@@ -81,6 +81,60 @@ def draw_grid_overlay(
     return img_copy
 
 
+def _downsample_naive_fast(
+    arr: np.ndarray,
+    grid_w: float,
+    grid_h: float,
+    num_cells_w: int,
+    num_cells_h: int,
+    kernel_w: int,
+    kernel_h: int,
+    offset_x: int,
+    offset_y: int,
+) -> np.ndarray:
+    """Vectorized per-cell naive-median downsample for RGB/RGBA arrays at bit==8.
+
+    Bit-exact with the per-cell reference loop in :func:`create_downsampled_image`, but
+    computed as a single stacked ``np.median`` over all cells at once instead of a Python
+    loop (~40x faster on large frames). The interior gathers each of the ``kernel_h*kernel_w``
+    taps with edge-clamped indices; the thin border of cells whose kernel actually clips the
+    image edge is then recomputed with the exact (non-duplicating) slice so the median matches
+    the reference for those cells too. ``.astype(np.uint8)`` truncates toward zero, matching
+    the reference's ``int()`` cast on the ``x.5`` medians that only occur at those edge cells.
+    """
+    H, W = arr.shape[:2]
+    C = arr.shape[2]
+    hw, hh = kernel_w // 2, kernel_h // 2
+    xs = np.clip((np.arange(num_cells_w) * grid_w + grid_w / 2).astype(int) + offset_x, 0, W - 1)
+    ys = np.clip((np.arange(num_cells_h) * grid_h + grid_h / 2).astype(int) + offset_y, 0, H - 1)
+
+    stack = np.empty((kernel_h * kernel_w, num_cells_h, num_cells_w, C), dtype=arr.dtype)
+    i = 0
+    for dy in range(-hh, hh + 1):
+        yy = np.clip(ys + dy, 0, H - 1)
+        for dx in range(-hw, hw + 1):
+            xx = np.clip(xs + dx, 0, W - 1)
+            stack[i] = arr[np.ix_(yy, xx)]
+            i += 1
+    med = np.median(stack, axis=0)  # (num_cells_h, num_cells_w, C), float
+
+    # Cells whose kernel would clip the image edge get fewer samples in the reference
+    # (it does NOT duplicate the border), so the clamped-gather median above is wrong for
+    # them. They form a thin border -> recompute exactly. Cheap: O(cells_w + cells_h).
+    edge_rows = np.where((ys - hh < 0) | (ys + hh >= H))[0]
+    edge_cols = np.where((xs - hw < 0) | (xs + hw >= W))[0]
+    if edge_rows.size or edge_cols.size:
+        cells = {(int(y), int(x)) for y in edge_rows for x in range(num_cells_w)}
+        cells |= {(int(y), int(x)) for x in edge_cols for y in range(num_cells_h)}
+        for y, x in cells:
+            cx, cy = int(xs[x]), int(ys[y])
+            x0, x1 = max(0, cx - hw), min(W, cx + hw + 1)
+            y0, y1 = max(0, cy - hh), min(H, cy + hh + 1)
+            med[y, x] = np.median(arr[y0:y1, x0:x1].reshape(-1, C), axis=0)
+
+    return med.astype(np.uint8)
+
+
 def create_downsampled_image(
     image: Image.Image,
     grid_w: int,
@@ -157,6 +211,17 @@ def create_downsampled_image(
 
     def quantize(value):
         return round(value * max_value / 255) * 255 // max_value
+
+    # Fast path for the common case (naive median, full 8-bit colour, RGB/RGBA): a single
+    # vectorized median over all cells instead of the per-cell Python loop below. Bit-exact
+    # (see _downsample_naive_fast). L mode, geometric median, and bit<8 keep the loop.
+    if median_type == "naive" and bit == 8 and mode in ("RGB", "RGBA"):
+        result = _downsample_naive_fast(
+            original_array, grid_w, grid_h, num_cells_w, num_cells_h,
+            kernel_w, kernel_h, offset_x, offset_y,
+        )
+        print("Downsampled image created.")
+        return Image.fromarray(result)
 
     for y_new in range(num_cells_h):
         for x_new in range(num_cells_w):

--- a/tests/test_downsample_vectorized.py
+++ b/tests/test_downsample_vectorized.py
@@ -1,0 +1,85 @@
+"""The vectorized fast path in create_downsampled_image (naive median, bit=8, RGB/RGBA)
+must be BIT-EXACT with the straightforward per-cell reference loop, including at the image
+edges (where the reference kernel clips instead of duplicating) and with float grid sizes
+and negative offsets."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from spritegrid.main import create_downsampled_image
+
+
+def _reference(img: Image.Image, grid_w, grid_h, cw, ch, ox, oy, kw=3, kh=3):
+    """Independent, obviously-correct per-cell naive-median downsample (mirrors the
+    original loop): non-duplicating edge slice, np.median, int() truncation."""
+    arr = np.array(img)
+    H, W = arr.shape[:2]
+    C = arr.shape[2]
+    hw, hh = kw // 2, kh // 2
+    out = np.zeros((ch, cw, C), np.uint8)
+    for y in range(ch):
+        for x in range(cw):
+            cx = min(max(0, int(x * grid_w + grid_w / 2) + ox), W - 1)
+            cy = min(max(0, int(y * grid_h + grid_h / 2) + oy), H - 1)
+            x0, x1 = max(0, cx - hw), min(W, cx + hw + 1)
+            y0, y1 = max(0, cy - hh), min(H, cy + hh + 1)
+            px = arr[y0:y1, x0:x1].reshape(-1, C)
+            m = np.median(px, axis=0)
+            out[y, x] = tuple(int(v) for v in m)
+    return out
+
+
+def _random_image(rng, W, H, mode):
+    C = 4 if mode == "RGBA" else 3
+    return Image.fromarray(rng.integers(0, 256, (H, W, C), dtype=np.uint8))
+
+
+@pytest.mark.parametrize("seed", range(30))
+def test_fast_path_bit_exact_vs_reference(seed):
+    rng = np.random.default_rng(seed)
+    mode = "RGBA" if seed % 2 else "RGB"
+    W = int(rng.integers(5, 64))
+    H = int(rng.integers(5, 64))
+    img = _random_image(rng, W, H, mode)
+    grid_w = int(rng.integers(3, min(W, 20) + 1))
+    grid_h = int(rng.integers(3, min(H, 20) + 1))
+    ox = int(rng.integers(-4, 5))
+    oy = int(rng.integers(-4, 5))
+    cw = max(1, round(W / grid_w))
+    ch = max(1, round(H / grid_h))
+
+    got = np.array(create_downsampled_image(img, grid_w, grid_h, cw, ch,
+                                            offset_x=ox, offset_y=oy))
+    ref = _reference(img, grid_w, grid_h, cw, ch, ox, oy)
+    assert np.array_equal(got, ref), f"mismatch seed={seed} mode={mode}"
+
+
+def test_more_cells_than_pixels_stresses_edges():
+    # cw/ch == W/H forces nearly every cell's kernel to clip -> exercises the edge recompute.
+    rng = np.random.default_rng(123)
+    img = _random_image(rng, 16, 12, "RGBA")
+    got = np.array(create_downsampled_image(img, 3, 3, 16, 12))
+    ref = _reference(img, 3, 3, 16, 12, 0, 0)
+    assert np.array_equal(got, ref)
+
+
+def test_float_grid_and_negative_offset():
+    # Our video pipeline passes fractional grid cells and shifted offsets.
+    rng = np.random.default_rng(7)
+    img = _random_image(rng, 60, 40, "RGB")
+    got = np.array(create_downsampled_image(img, 5.5, 4.5, 24, 18,
+                                            offset_x=-3, offset_y=2))
+    ref = _reference(img, 5.5, 4.5, 24, 18, -3, 2)
+    assert np.array_equal(got, ref)
+
+
+def test_non_square_kernel_uses_reference_loop_unchanged():
+    # (3,5) kernel still goes through the fast path (naive, bit8) -> must match reference.
+    rng = np.random.default_rng(9)
+    img = _random_image(rng, 40, 40, "RGB")
+    got = np.array(create_downsampled_image(img, 6, 6, 6, 6, kernel_size=(3, 5)))
+    ref = _reference(img, 6, 6, 6, 6, 0, 0, kw=3, kh=5)
+    assert np.array_equal(got, ref)


### PR DESCRIPTION
## Problem

`create_downsampled_image` downsamples by looping over **every output cell** in Python and
running a separate `np.median` on each cell's KxK kernel. On a 1280×720 → 256×131 frame
that's ~34k `np.median` calls per frame ≈ **306 ms/frame** — the bottleneck for large images
and every video/animation frame.

## Fix

Add a vectorized fast path for the common case (`median_type='naive'`, `bit==8`, RGB/RGBA):
gather all `kernel_h*kernel_w` taps and take **one stacked `np.median` over all cells at
once**. The thin border of cells whose kernel clips the image edge is recomputed with the
exact non-duplicating slice, so the output is **bit-exact** with the original loop
(`.astype(uint8)` truncates toward zero, matching the loop's `int()` cast on the `x.5`
medians that only occur at those edge cells).

**L mode, geometric median, and `bit<8` keep the original loop untouched** — zero behaviour
change there.

## Result

**~7.8 ms/frame vs ~306 ms — ≈39× faster** on a 1280×720 → 256×131 frame. Whole-suite time
unchanged.

## Correctness

New `tests/test_downsample_vectorized.py`: **33 randomized bit-exactness checks** against an
independent per-cell reference loop, covering RGB/RGBA, tiny images (edge-dominated), float
grid sizes, negative offsets, non-square kernels, and a more-cells-than-pixels edge stress.
Full suite: **259 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)